### PR TITLE
Remove entry points for payments

### DIFF
--- a/components/Chat/Input/Input.tsx
+++ b/components/Chat/Input/Input.tsx
@@ -25,7 +25,6 @@ import { sendMessage } from "../../../utils/message";
 import { TextInputWithValue } from "../../../utils/str";
 import AddAttachmentButton from "../Attachment/AddAttachmentButton";
 import { MessageToDisplay } from "../Message/Message";
-import SendMoneyButton from "../Transaction/SendMoneyButton";
 import ChatInputReplyPreview from "./InputReplyPreview";
 
 const getSendButtonType = (input: string): "DEFAULT" | "HIGHER" => {
@@ -134,7 +133,6 @@ export default function ChatInput() {
       )}
       <View style={styles.chatInputContainer}>
         <AddAttachmentButton />
-        {!conversation?.isGroup && <SendMoneyButton />}
         <TextInput
           autoCorrect={isDesktop ? false : undefined}
           autoComplete={isDesktop ? "off" : undefined}

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -308,13 +308,6 @@ export default function ProfileScreen({
           style={styles.tableView}
         />
       )}
-      {isMyProfile && (
-        <TableView
-          items={balanceItems}
-          title="BALANCE"
-          style={styles.tableView}
-        />
-      )}
 
       {usernamesItems.length > 0 && (
         <TableView


### PR DESCRIPTION
Remove payments button near message input, and remove balance on profile settings page. Keeping the rest of the logic in place outside of entry points because this is a temporary change. Let me know if I should remove that code as part of this PR. 
<img width="300" alt="Screenshot 2024-06-05 at 9 02 15 AM" src="https://github.com/Unshut-Labs/converse-app/assets/35409260/e7623818-f7c6-4a5a-8d14-ecfdb4a6d89b">
<img width="300" src="https://github.com/Unshut-Labs/converse-app/assets/35409260/e15c1234-4ad7-4f45-9d3f-ffa52270dca1"/>
