### PR TITLE
Add logic for 3 or fewer emojis

### DIFF
--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -38,7 +38,10 @@ import {
   getMessageContentType,
   isContentType,
 } from "../../../utils/xmtpRN/contentTypes";
-import { removePrefixesAndTrailingSlash } from "../../../utils/xmtpRN/messages";
+import {
+  isAllEmojisAndMaxThree,
+  removePrefixesAndTrailingSlash,
+} from "../../../utils/xmtpRN/messages";
 import ClickableText from "../../ClickableText";
 import ActionButton from "../ActionButton";
 import AttachmentMessagePreview from "../Attachment/AttachmentMessagePreview";
@@ -80,9 +83,14 @@ const MessageSender = ({ message }: { message: MessageToDisplay }) => {
 
 function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
   const styles = useStyles();
+  const hideBackground = isAllEmojisAndMaxThree(message.content);
 
   const metadata = (
-    <MessageTimestamp message={message} white={message.fromMe} />
+    <MessageTimestamp
+      message={message}
+      white={message.fromMe}
+      hiddenBackground={hideBackground}
+    />
   );
 
   let messageContent: ReactNode;
@@ -217,7 +225,11 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
           }}
           ref={swipeableRef}
         >
-          <ChatMessageActions message={message} reactions={reactions}>
+          <ChatMessageActions
+            message={message}
+            reactions={reactions}
+            hideBackground={hideBackground}
+          >
             {isContentType("text", message.contentType) && (
               <FramesPreviews message={message} />
             )}

--- a/components/Chat/Message/MessageActions.tsx
+++ b/components/Chat/Message/MessageActions.tsx
@@ -65,7 +65,10 @@ const MessageTail = (props: any) => {
     <MessageTailAnimated
       {...props}
       fill={
-        props.fromMe
+        // No tail needed if no background
+        props.hideBackground
+          ? "transparent"
+          : props.fromMe
           ? myMessageBubbleColor(props.colorScheme)
           : messageBubbleColor(props.colorScheme)
       }
@@ -79,12 +82,14 @@ type Props = {
   reactions: {
     [senderAddress: string]: MessageReaction | undefined;
   };
+  hideBackground: boolean;
 };
 
 export default function ChatMessageActions({
   children,
   message,
   reactions,
+  hideBackground = false,
 }: Props) {
   const { conversation } = useConversationContext(["conversation"]);
   const isAttachment = isAttachmentMessage(message.contentType);
@@ -341,7 +346,9 @@ export default function ChatMessageActions({
             styles.messageBubble,
             message.fromMe ? styles.messageBubbleMe : undefined,
             {
-              backgroundColor: initialBubbleBackgroundColor,
+              backgroundColor: hideBackground
+                ? "transparent"
+                : initialBubbleBackgroundColor,
             },
             highlightingMessage ? animatedBackgroundStyle : undefined,
             Platform.select({
@@ -395,6 +402,7 @@ export default function ChatMessageActions({
                 ]}
                 fromMe={message.fromMe}
                 colorScheme={colorScheme}
+                hideBackground={hideBackground}
               />
             )}
         </ReanimatedTouchableOpacity>

--- a/components/Chat/Message/MessageTimestamp.tsx
+++ b/components/Chat/Message/MessageTimestamp.tsx
@@ -8,13 +8,27 @@ import { MessageToDisplay } from "./Message";
 type Props = {
   message: MessageToDisplay;
   white: boolean;
+  hiddenBackground?: boolean;
 };
 
-export default function MessageTimestamp({ message, white }: Props) {
+export default function MessageTimestamp({
+  message,
+  white,
+  hiddenBackground = false,
+}: Props) {
   const styles = useStyles();
   return (
     <View style={styles.metadata}>
-      <Text style={[styles.time, white ? styles.timeWhite : undefined]}>
+      <Text
+        style={[
+          styles.time,
+          hiddenBackground
+            ? styles.timeOnHiddenBackground
+            : white
+            ? styles.timeWhite
+            : undefined,
+        ]}
+      >
         {getTime(message.sent)}
       </Text>
     </View>
@@ -35,6 +49,9 @@ const useStyles = () => {
       fontSize: 8,
       color: textPrimaryColor(colorScheme),
       marginRight: 3,
+    },
+    timeOnHiddenBackground: {
+      color: textPrimaryColor(colorScheme),
     },
     timeWhite: {
       color: "white",

--- a/utils/xmtpRN/messages.ts
+++ b/utils/xmtpRN/messages.ts
@@ -331,3 +331,24 @@ export const removePrefixesAndTrailingSlash = (url: string) => {
   result = result.replace(trailingSlashRegex, "");
   return result;
 };
+
+const isEmoji = (character: string) => {
+  const emojiRegex = /[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu;
+  return emojiRegex.test(character);
+};
+
+export const isAllEmojisAndMaxThree = (str: string) => {
+  const strWithoutSpaces = str.replaceAll(" ", "");
+  const iterator = [...strWithoutSpaces];
+  let emojiCount = 0;
+
+  for (const char of iterator) {
+    if (isEmoji(char)) {
+      emojiCount++;
+    } else {
+      // break if any aren't emojis
+      return false;
+    }
+  }
+  return emojiCount > 0 && emojiCount <= 3;
+};


### PR DESCRIPTION
This PR updates the current emoji logic to support showing no background when the entirety of the message content is 3 or fewer emojis. (e.g. iMessage)

This required a bunch of detail changes and testing e.g. updating the message tail and replies. Everything looks correct to me with the exception of 3 or fewer emojis in a reply hides the message tail, but fixing this would involve a reworking of how replies are done, so I propose we leave this edge case as-is. 

Screenshots below including incoming/outgoing, light/dark mode, with/without replies. 

Light mode outgoing without replies (and including reactions):
<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/c9764107-f705-41f0-9890-6ee7812bcedc" width="200" />

Light mode outgoing with replies:
<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/43bed478-7450-47fc-834e-7383ed46c429" width="200" />

Light mode incoming: 
<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/1be29cca-69e9-44c6-b599-70b94bba79dd" width="200" />

Dark mode outgoing:
<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/c702e9b3-6dda-47b9-8306-904fc8fd0639" width="200" />

Dark mode incoming: 
<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/1ad73d3e-1137-4f1a-b704-49b812403763" width="200" />
