### PR TITLE
Glow up tweaks, util tests

### DIFF
--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -29,6 +29,10 @@ import {
 import { getRelativeDate } from "../../../utils/date";
 import { isDesktop } from "../../../utils/device";
 import { converseEventEmitter } from "../../../utils/events";
+import {
+  getUrlToRender,
+  isAllEmojisAndMaxThree,
+} from "../../../utils/messageContent";
 import { LimitedMap } from "../../../utils/objects";
 import { getPreferredName } from "../../../utils/profile";
 import { getMessageReactions } from "../../../utils/reactions";
@@ -38,10 +42,6 @@ import {
   getMessageContentType,
   isContentType,
 } from "../../../utils/xmtpRN/contentTypes";
-import {
-  getUrlToRender,
-  isAllEmojisAndMaxThree,
-} from "../../../utils/xmtpRN/messages";
 import ClickableText from "../../ClickableText";
 import ActionButton from "../ActionButton";
 import AttachmentMessagePreview from "../Attachment/AttachmentMessagePreview";

--- a/components/ConversationList/RequestsButton.tsx
+++ b/components/ConversationList/RequestsButton.tsx
@@ -10,14 +10,12 @@ import {
 
 import { NavigationParamList } from "../../screens/Navigation/Navigation";
 import {
-  actionSecondaryColor,
   clickedItemBackgroundColor,
   listItemSeparatorColor,
   primaryColor,
   textPrimaryColor,
   textSecondaryColor,
 } from "../../utils/colors";
-import Picto from "../Picto/Picto";
 
 type Props = { requestsCount: number } & NativeStackScreenProps<
   NavigationParamList,
@@ -37,16 +35,6 @@ export default function RequestsButton({ navigation, requestsCount }: Props) {
       <View style={styles.requestsHeader}>
         <Text style={styles.requestsHeaderTitle}>Requests</Text>
         <Text style={styles.requestsCount}>{requestsCount}</Text>
-        <Picto
-          picto="chevron.right"
-          weight="semibold"
-          color={
-            Platform.OS === "android"
-              ? textPrimaryColor(colorScheme)
-              : actionSecondaryColor(colorScheme)
-          }
-          size={Platform.OS === "android" ? 25 : 10}
-        />
       </View>
     </TouchableHighlight>
   );
@@ -62,7 +50,8 @@ const useStyles = () => {
         default: {
           paddingVertical: 8,
           paddingRight: 24,
-          marginLeft: 32,
+          paddingLeft: 32,
+          height: 40,
           borderBottomWidth: 0.25,
           borderBottomColor: listItemSeparatorColor(colorScheme),
         },

--- a/components/ConversationList/SuspectedSpamButton.tsx
+++ b/components/ConversationList/SuspectedSpamButton.tsx
@@ -64,9 +64,11 @@ const useStyles = () => {
         default: {
           paddingVertical: 8,
           paddingRight: 24,
-          marginLeft: 32,
+          paddingLeft: 32,
           borderBottomWidth: 0.25,
           borderBottomColor: listItemSeparatorColor(colorScheme),
+          borderTopWidth: 0.25,
+          borderTopColor: listItemSeparatorColor(colorScheme),
         },
         android: {
           paddingVertical: 12,

--- a/components/ConversationListItem.tsx
+++ b/components/ConversationListItem.tsx
@@ -29,11 +29,10 @@ import {
   badgeColor,
   clickedItemBackgroundColor,
   dangerColor,
-  listItemSeparatorColor,
   textPrimaryColor,
   textSecondaryColor,
 } from "../utils/colors";
-import { getRelativeDateTime } from "../utils/date";
+import { getMinimalDate } from "../utils/date";
 import { isDesktop } from "../utils/device";
 import { converseEventEmitter } from "../utils/events";
 import { navigate } from "../utils/navigation";
@@ -75,7 +74,7 @@ const ConversationListItem = memo(function ConversationListItem({
   conversationOpened,
 }: ConversationListItemProps) {
   const styles = getStyles(colorScheme);
-  const timeToShow = getRelativeDateTime(conversationTime);
+  const timeToShow = getMinimalDate(conversationTime as number);
   const setTopicsData = useChatStore((s) => s.setTopicsData);
   const setPeersStatus = useSettingsStore((s) => s.setPeersStatus);
   const isSplitScreen = useIsSplitScreen();
@@ -350,9 +349,7 @@ const getStyles = (colorScheme: ColorSchemeName) =>
     rowSeparator: Platform.select({
       android: {},
       default: {
-        height: 77,
-        borderBottomWidth: 0.25,
-        borderBottomColor: listItemSeparatorColor(colorScheme),
+        height: 80,
       },
     }),
     rowSeparatorMargin: {

--- a/utils/date.test.ts
+++ b/utils/date.test.ts
@@ -2,7 +2,7 @@ import { format } from "date-fns";
 import { enUS, fr } from "date-fns/locale";
 import { getLocales } from "react-native-localize";
 
-import { getRelativeDate, getRelativeDateTime } from "./date";
+import { getMinimalDate, getRelativeDate, getRelativeDateTime } from "./date";
 
 jest.mock("react-native-localize", () => ({
   getLocales: jest.fn(),
@@ -144,5 +144,41 @@ describe("getRelativeDate with fr-FR locale", () => {
     const date = new Date();
     date.setDate(date.getDate() - 10);
     expect(getRelativeDate(date)).toBe(format(date, "P", { locale: fr }));
+  });
+});
+
+describe("getMinimalDate", () => {
+  const now = Date.now();
+
+  it("should return an empty string for falsy input", () => {
+    expect(getMinimalDate(0)).toBe("");
+  });
+
+  it("should return correct minimal timestamp for seconds", () => {
+    expect(getMinimalDate(now - 5000)).toBe("5s");
+  });
+
+  it("should return correct minimal timestamp for minutes", () => {
+    expect(getMinimalDate(now - 5 * 60 * 1000)).toBe("5m");
+  });
+
+  it("should return correct minimal timestamp for hours", () => {
+    expect(getMinimalDate(now - 5 * 60 * 60 * 1000)).toBe("5h");
+  });
+
+  it("should return correct minimal timestamp for days", () => {
+    expect(getMinimalDate(now - 5 * 24 * 60 * 60 * 1000)).toBe("5d");
+  });
+
+  it("should return correct minimal timestamp for weeks", () => {
+    expect(getMinimalDate(now - 14 * 24 * 60 * 60 * 1000)).toBe("2w");
+  });
+
+  it("should return correct minimal timestamp for months", () => {
+    expect(getMinimalDate(now - 60 * 24 * 60 * 60 * 1000)).toBe("2mo");
+  });
+
+  it("should return correct minimal timestamp for years", () => {
+    expect(getMinimalDate(now - 2 * 365 * 24 * 60 * 60 * 1000)).toBe("2y");
   });
 });

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -56,3 +56,26 @@ export const getTime = (date: number | Date) => {
   const locale = getLocale();
   return format(date, "p", { locale });
 };
+
+export const getMinimalDate = (date: number) => {
+  if (!date) return "";
+  // To-do: Add supporting locale logic
+  // const locale = getLocale();
+  const diff = Date.now() - date;
+
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const weeks = Math.floor(days / 7);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(days / 365);
+
+  if (years > 0) return `${years}y`;
+  if (months > 0) return `${months}mo`;
+  if (weeks > 0) return `${weeks}w`;
+  if (days > 0) return `${days}d`;
+  if (hours > 0) return `${hours}h`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${seconds}s`;
+};

--- a/utils/messageContent.test.ts
+++ b/utils/messageContent.test.ts
@@ -1,0 +1,67 @@
+import { getUrlToRender, isAllEmojisAndMaxThree } from "./messageContent";
+
+describe("isAllEmojisAndMaxThree", () => {
+  it("should return true for strings with up to three emojis and no spaces", () => {
+    expect(isAllEmojisAndMaxThree("😊😊😊")).toBe(true);
+    expect(isAllEmojisAndMaxThree("😊😊")).toBe(true);
+    expect(isAllEmojisAndMaxThree("😊")).toBe(true);
+  });
+
+  it("should return false for strings with more than three emojis", () => {
+    expect(isAllEmojisAndMaxThree("😊😊😊😊")).toBe(false);
+  });
+
+  it("should return false for strings containing non-emoji characters", () => {
+    expect(isAllEmojisAndMaxThree("😊a😊")).toBe(false);
+    expect(isAllEmojisAndMaxThree("😊😊😊a")).toBe(false);
+  });
+
+  it("should return true for strings with up to three emojis and spaces", () => {
+    expect(isAllEmojisAndMaxThree("😊 😊 😊")).toBe(true);
+    expect(isAllEmojisAndMaxThree("😊 😊")).toBe(true);
+    expect(isAllEmojisAndMaxThree("😊")).toBe(true);
+  });
+
+  it("should return false for strings with more than three emojis even with spaces", () => {
+    expect(isAllEmojisAndMaxThree("😊 😊 😊 😊")).toBe(false);
+  });
+
+  it("should return false for empty strings", () => {
+    expect(isAllEmojisAndMaxThree("")).toBe(false);
+  });
+});
+
+describe("getUrlToRender", () => {
+  it("should return the hostname of a full URL", () => {
+    expect(getUrlToRender("https://example.com/path")).toBe("example.com");
+    expect(getUrlToRender("http://example.com")).toBe("example.com");
+    expect(getUrlToRender("https://subdomain.example.com/path")).toBe(
+      "subdomain.example.com"
+    );
+    expect(getUrlToRender("www://example.com")).toBe("example.com");
+    expect(getUrlToRender("ftp://example.com/resource")).toBe("example.com");
+  });
+
+  it("should return the hostname for URLs with different ports", () => {
+    expect(getUrlToRender("http://example.com:8080/path")).toBe("example.com");
+    expect(getUrlToRender("https://example.com:443")).toBe("example.com");
+  });
+
+  it("should return the hostname for URLs with query parameters", () => {
+    expect(getUrlToRender("https://example.com/path?query=123")).toBe(
+      "example.com"
+    );
+    expect(
+      getUrlToRender("https://example.com/path?query=123&another=456")
+    ).toBe("example.com");
+  });
+
+  it("should handle URLs with fragments", () => {
+    expect(getUrlToRender("https://example.com/path#fragment")).toBe(
+      "example.com"
+    );
+    expect(getUrlToRender("https://example.com/path?query=123#fragment")).toBe(
+      "example.com"
+    );
+  });
+});

--- a/utils/messageContent.ts
+++ b/utils/messageContent.ts
@@ -1,0 +1,25 @@
+export const getUrlToRender = (url: string) => {
+  const fullUrl = new URL(url);
+  return fullUrl.hostname;
+};
+
+const isEmoji = (character: string) => {
+  const emojiRegex = /[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu;
+  return emojiRegex.test(character);
+};
+
+export const isAllEmojisAndMaxThree = (str: string) => {
+  const strWithoutSpaces = str.replaceAll(" ", "");
+  const iterator = [...strWithoutSpaces];
+  let emojiCount = 0;
+
+  for (const char of iterator) {
+    if (isEmoji(char)) {
+      emojiCount++;
+    } else {
+      // break if any aren't emojis
+      return false;
+    }
+  }
+  return emojiCount > 0 && emojiCount <= 3;
+};


### PR DESCRIPTION
"Glow up" change which includes:

- Removing chevrons
- Removing unneeded horizontal lines and increasing spacing between convos
- Changing date formatting to minimalistic like 1w, etc. Note: the date-fns package we're using didn't have a way to do this that I could find, so I added it in custom. We'll need to add additional locale support for that for whatever these abbrevs are in the other locales we support.
- Added tests to previous util and moved out of the /RN folder since jest wasn't liking it there. 

<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/613f0f58-5f5a-4be5-bfe5-ef7c88eaeebd" width="200" />

Dark mode:
<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/17129463-619b-454e-a23c-b204e9014604" width="200" />
