### PR TITLE
Fix group name for attachments

### DIFF
--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -119,7 +119,6 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
     default: {
       messageContent = (
         <>
-          {isGroup && !message.fromMe && <MessageSender message={message} />}
           <ClickableText
             style={[
               styles.messageText,
@@ -176,6 +175,7 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
       {message.dateChange && (
         <Text style={styles.date}>{getRelativeDate(message.sent)}</Text>
       )}
+      {isGroup && !message.fromMe && <MessageSender message={message} />}
       {!showInBubble && messageContent}
       {showInBubble && (
         <Swipeable
@@ -459,9 +459,10 @@ const useStyles = () => {
       zIndex: -1,
     },
     groupSender: {
-      fontSize: 15,
-      fontWeight: "500",
-      color: textPrimaryColor(colorScheme),
+      fontSize: 11,
+      color: textSecondaryColor(colorScheme),
+      marginLeft: 24,
+      marginTop: 16,
     },
   });
 };


### PR DESCRIPTION
Adds sender message outside bubble for groups; includes sender name for attachments. 

Light/dark mode here:
<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/f991298a-3137-403f-a577-9236bf9076ec" width="200" />

<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/0ff5011f-5164-4999-b1b4-ca00fd246590" width="200" />