### PR TITLE
Filters undisplayed messages outside loop

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -107,7 +107,6 @@ const getListArray = (
         if (
           nextMessage.senderAddress === message.senderAddress &&
           !nextMessageDateChange &&
-          !isContentType("reaction", nextMessage.contentType) &&
           !isContentType("groupUpdated", nextMessage.contentType)
         ) {
           message.hasNextMessageInSeries = true;


### PR DESCRIPTION
There was an edge case with the `hasNextMessage` logic where a reaction to a previous message would be considered a more recent message and throw off the logic as to whether or not to show a tail/message sent indicator. This removes the reaction/read receipt types before entering the loop so they don't factor into the check at all.

Here's some test cases with this; definitely let me know if you can think of any edges this logic would miss.

<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/66adc5e5-77cf-466e-ba6c-46a79f505267" width="200" />
<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/67d37c0b-7b48-4783-b17e-1bb191875f5e" width="200" />

When merged should close out https://github.com/Unshut-Labs/converse-app/issues/102
