### PR TITLE
hide the privy wallet balance indicator for now

### DIFF
--- a/components/ConversationList/ProfileSettingsButton.tsx
+++ b/components/ConversationList/ProfileSettingsButton.tsx
@@ -42,7 +42,8 @@ export default function ProfileSettingsButton() {
     setStringBalance(str);
     setStringSize(str.length * 10 + 10);
   }, [USDCBalance]);
-  if (isPrivy) {
+  // Disabled with "false" until payments UX sorted
+  if (isPrivy && false) {
     if (Platform.OS === "android" || Platform.OS === "web") {
       return (
         <Button


### PR DESCRIPTION
Fixes "$0" in top left:
![image](https://github.com/Unshut-Labs/converse-app/assets/510695/e9205bc3-6649-453a-b058-4f13405926e2)
