### PR TITLE
Fix header on android

### DIFF
--- a/components/Conversation/ConversationTitle.tsx
+++ b/components/Conversation/ConversationTitle.tsx
@@ -16,7 +16,7 @@ import { XmtpConversation } from "../../data/store/chatStore";
 import { useGroupName } from "../../hooks/useGroupName";
 import { useGroupPhoto } from "../../hooks/useGroupPhoto";
 import { NavigationParamList } from "../../screens/Navigation/Navigation";
-import { headerTitleStyle, textPrimaryColor } from "../../utils/colors";
+import { textPrimaryColor } from "../../utils/colors";
 import { getPreferredAvatar } from "../../utils/profile";
 import { conversationName, getTitleFontScale } from "../../utils/str";
 import Avatar from "../Avatar";
@@ -126,6 +126,7 @@ export default function ConversationTitle({
         style={{
           flexDirection: "row",
           justifyContent: "space-between",
+          left: Platform.OS === "android" ? -36 : 0,
           width: "100%",
           alignItems: "center",
           paddingRight: 40,
@@ -135,11 +136,10 @@ export default function ConversationTitle({
         <Text
           style={[
             {
+              // For large groups where text will overflow the container
+              maxWidth: "80%",
               color: textPrimaryColor(colorScheme),
-              fontSize:
-                Platform.OS === "ios"
-                  ? 14 * getTitleFontScale()
-                  : headerTitleStyle(colorScheme).fontSize,
+              fontSize: 14 * getTitleFontScale(),
             },
           ]}
           numberOfLines={1}
@@ -159,7 +159,8 @@ export default function ConversationTitle({
         ) : (
           <Picto
             picto="info.circle"
-            size={16}
+            // Reason this is smaller than avatar is when it's the same size, looks like more of an error icon than an avatar placeholder
+            size={Platform.OS === "android" ? 20 : 16}
             color={textPrimaryColor(colorScheme)}
             style={{
               marginRight: Platform.OS === "android" ? 24 : 16,


### PR DESCRIPTION
Avatar was cut off on Android in the new header, see screenshot:
<img src="https://github.com/Unshut-Labs/converse-app/assets/35409260/df6a01bf-5c74-4f55-ac6c-32379d8e240e" width="200" />

This PR fixes that:
<img width="300" alt="Screenshot 2024-06-21 at 2 31 36 PM" src="https://github.com/Unshut-Labs/converse-app/assets/35409260/c07a22bf-73bc-49d4-b2cf-7d6ba609849f">

Also checked the picto icon when there is no avatar:
<img width="300" alt="Screenshot 2024-06-21 at 2 42 18 PM" src="https://github.com/Unshut-Labs/converse-app/assets/35409260/f5fafdd5-2672-42a1-a072-d24fa8594a22">

And dark mode:
<img width="300" alt="Screenshot 2024-06-21 at 2 43 55 PM" src="https://github.com/Unshut-Labs/converse-app/assets/35409260/fab2dfdd-162c-4260-bf26-140ca72e8549">

And long group names to ensure these don't overflow the container:
<img width="300" alt="Screenshot 2024-06-21 at 2 44 39 PM" src="https://github.com/Unshut-Labs/converse-app/assets/35409260/b32a63de-cb87-4a6b-92d5-f164460cf643">

Checked iOS for no regressions as well:
<img width="300" src="https://github.com/Unshut-Labs/converse-app/assets/35409260/60508133-891a-479d-8243-83f323bbddc0" />
<img width="300" src="https://github.com/Unshut-Labs/converse-app/assets/35409260/95b0e70f-8374-4ab2-96cc-868f51198ab0" />

