### PR TITLE
feat: Custom action sheet for iOS

### DIFF
--- a/components/Chat/Message/MessageActionSheet.tsx
+++ b/components/Chat/Message/MessageActionSheet.tsx
@@ -1,0 +1,212 @@
+import React, { useCallback, useState } from "react";
+import { Modal, TouchableOpacity, Text, StyleSheet } from "react-native";
+import {
+  GestureDetector,
+  Gesture,
+  GestureHandlerRootView,
+} from "react-native-gesture-handler";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+} from "react-native-reanimated";
+
+export interface MessageActionSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  options: string[];
+  cancelButtonIndex?: number;
+  destructiveButtonIndex?: number | number[];
+  onSelect: (index: number) => void;
+  title?: string;
+}
+
+export interface MessageActionSheetOptions {
+  options: string[];
+  message?: string;
+  cancelButtonIndex?: number;
+  destructiveButtonIndex?: number | number[];
+  title?: string;
+}
+
+export const useMessageActionSheet = () => {
+  const [visible, setVisible] = useState(false);
+  const [currentOptions, setCurrentOptions] =
+    useState<MessageActionSheetOptions | null>(null);
+  const [onSelectCallback, setOnSelectCallback] = useState<
+    ((index: number) => void) | null
+  >(null);
+
+  const showActionSheetWithOptions = useCallback(
+    (options: MessageActionSheetOptions, callback: (index: number) => void) => {
+      setCurrentOptions(options);
+      setOnSelectCallback(() => callback);
+      setVisible(true);
+    },
+    []
+  );
+
+  const hideActionSheet = useCallback(() => {
+    setVisible(false);
+  }, []);
+
+  const handleSelect = useCallback(
+    (index: number) => {
+      if (onSelectCallback) {
+        onSelectCallback(index);
+      }
+      hideActionSheet();
+    },
+    [onSelectCallback, hideActionSheet]
+  );
+
+  const actionSheet = currentOptions ? (
+    <MessageActionSheet
+      visible={visible}
+      onClose={hideActionSheet}
+      options={currentOptions.options}
+      cancelButtonIndex={currentOptions.cancelButtonIndex}
+      destructiveButtonIndex={currentOptions.destructiveButtonIndex}
+      onSelect={handleSelect}
+      title={currentOptions.title}
+    />
+  ) : null;
+
+  return {
+    showActionSheetWithOptions,
+    actionSheet,
+  };
+};
+
+const MessageActionSheet: React.FC<MessageActionSheetProps> = ({
+  visible,
+  onClose,
+  options,
+  cancelButtonIndex,
+  destructiveButtonIndex,
+  onSelect,
+  title,
+}) => {
+  const translateY = useSharedValue(0);
+
+  const gesture = Gesture.Pan()
+    .onUpdate((event) => {
+      if (event.translationY > 0) {
+        translateY.value = event.translationY;
+      }
+    })
+    .onEnd((event) => {
+      if (event.translationY > 50) {
+        onClose();
+      } else {
+        translateY.value = withSpring(0);
+      }
+    });
+
+  const animatedStyles = useAnimatedStyle(() => {
+    return {
+      transform: [{ translateY: translateY.value }],
+    };
+  });
+
+  const isDestructive = (index: number) => {
+    if (typeof destructiveButtonIndex === "number") {
+      return index === destructiveButtonIndex;
+    }
+    return (
+      Array.isArray(destructiveButtonIndex) &&
+      destructiveButtonIndex.includes(index)
+    );
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <TouchableOpacity style={styles.overlay} onPress={onClose}>
+          <GestureDetector gesture={gesture}>
+            <Animated.View style={[styles.actionSheet, animatedStyles]}>
+              {title && <Text style={styles.title}>{title}</Text>}
+              {options.map((option, index) => (
+                <TouchableOpacity
+                  key={index}
+                  style={[
+                    styles.option,
+                    isDestructive(index) && styles.destructiveOption,
+                    index === cancelButtonIndex && styles.cancelOption,
+                  ]}
+                  onPress={() => {
+                    onSelect(index);
+                    onClose();
+                  }}
+                >
+                  <Text
+                    style={[
+                      styles.optionText,
+                      isDestructive(index) && styles.destructiveText,
+                      index === cancelButtonIndex && styles.cancelText,
+                    ]}
+                  >
+                    {option}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </Animated.View>
+          </GestureDetector>
+        </TouchableOpacity>
+      </GestureHandlerRootView>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.4)",
+    justifyContent: "flex-end",
+  },
+  actionSheet: {
+    backgroundColor: "white",
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 16,
+    maxHeight: "80%",
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: "bold",
+    marginBottom: 10,
+    textAlign: "center",
+  },
+  message: {
+    fontSize: 14,
+    marginBottom: 10,
+    textAlign: "center",
+  },
+  option: {
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#ccc",
+  },
+  optionText: {
+    fontSize: 16,
+  },
+  destructiveOption: {
+    // Style for destructive options
+  },
+  destructiveText: {
+    color: "red",
+  },
+  cancelOption: {
+    // Style for cancel option
+  },
+  cancelText: {
+    fontWeight: "bold",
+  },
+});
+
+export default MessageActionSheet;

--- a/components/StateHandlers/ActionSheetStateHandler.ios.tsx
+++ b/components/StateHandlers/ActionSheetStateHandler.ios.tsx
@@ -1,0 +1,41 @@
+import { useCallback, useEffect } from "react";
+
+import { useAppStore } from "../../data/store/appStore";
+import {
+  MessageActionSheetOptions,
+  useMessageActionSheet,
+} from "../Chat/Message/MessageActionSheet";
+
+export let showActionSheetWithOptions: (
+  options: MessageActionSheetOptions,
+  callback: (i?: number) => void | Promise<void>
+) => void;
+
+export default function ActionSheetStateHandler() {
+  const {
+    showActionSheetWithOptions: _showActionSheetWithOptions,
+    actionSheet,
+  } = useMessageActionSheet();
+
+  const wrappedShowActionSheetWithOptions = useCallback(
+    (
+      options: MessageActionSheetOptions,
+      callback: (i?: number) => void | Promise<void>
+    ) => {
+      useAppStore.getState().setActionSheetShown(true);
+      _showActionSheetWithOptions(options, (i?: number) => {
+        useAppStore.getState().setActionSheetShown(false);
+        if (callback) {
+          callback(i);
+        }
+      });
+    },
+    [_showActionSheetWithOptions]
+  );
+
+  useEffect(() => {
+    showActionSheetWithOptions = wrappedShowActionSheetWithOptions;
+  }, [wrappedShowActionSheetWithOptions]);
+
+  return actionSheet;
+}


### PR DESCRIPTION
We want to modernize the look and feel of the action sheet to set the stage for bringing in onchain message interactions like tipping and minting. Since `react-native-action-sheet` only supports custom action sheets for Android/web, we need to build our own for iOS.

Here is the design we are moving towards:
<img src="https://github.com/Unshut-Labs/converse-app/assets/510695/776a88db-0acc-4769-88a8-0fcbee994a20" width=350 />

This PR does not implement those designs, just puts the infrastructure in place so that we can get started on that. Here's what it looks like today:

<img src="https://github.com/Unshut-Labs/converse-app/assets/510695/fbd2027e-82a2-44b6-9e6d-e0edcbd39d7b" width=350 />

Note this PR currently keeps in place the existing implementation for Android/web. It might make sense to migrate them over too.
