### PR TITLE
fix: Add handling for when images fail to load

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
         "ignoreDOMComponents": true
       }
     ],
+    "react/jsx-key": "error",
 
     "prettier/prettier": "off" // We use prettier manually on the side
   },

--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -1,8 +1,9 @@
 import { actionSecondaryColor, textSecondaryColor } from "@styles/colors";
 import { AvatarSizes } from "@styles/sizes";
+import { Image } from "expo-image";
+import { useCallback, useState } from "react";
 import {
   ColorSchemeName,
-  Image,
   ImageStyle,
   StyleProp,
   StyleSheet,
@@ -29,9 +30,20 @@ export default function Avatar({
   const colorScheme = useColorScheme();
   const styles = getStyles(colorScheme, size);
   const firstLetter = name ? name.charAt(0).toUpperCase() : "";
+  const [didError, setDidError] = useState(false);
 
-  return uri ? (
+  const handleImageError = useCallback(() => {
+    setDidError(true);
+  }, []);
+
+  const handleImageLoad = useCallback(() => {
+    setDidError(false);
+  }, []);
+
+  return uri && !didError ? (
     <Image
+      onLoad={handleImageLoad}
+      onError={handleImageError}
       key={`${uri}-${color}-${colorScheme}`}
       source={{ uri }}
       style={[styles.image, style]}


### PR DESCRIPTION
Added state for managing image loading errors
Changed to Expo Image for better caching and performance

Old Loading
https://github.com/Unshut-Labs/converse-app/assets/23103150/c027a07d-43a1-40ff-a73e-7550ee3b1090

New Loading
https://github.com/Unshut-Labs/converse-app/assets/23103150/5238c0e1-24e2-4603-89b3-460441bfdf06 

Closes https://github.com/Unshut-Labs/converse-app/issues/184