### PR TITLE
fix: Secondary Button Icons dark mode

### DIFF
--- a/components/Button/Button.ios.tsx
+++ b/components/Button/Button.ios.tsx
@@ -71,7 +71,11 @@ export default function Button({
             styles.picto,
             variant === "text" ? { paddingLeft: 15 } : undefined,
           ]}
-          color={variant === "text" ? primaryColor(colorScheme) : "white"}
+          color={
+            variant === "text"
+              ? primaryColor(colorScheme)
+              : inversePrimaryColor(colorScheme)
+          }
         />
       )}
       <Text


### PR DESCRIPTION
Fixed dark mode secondary icons

![Simulator Screenshot - iPhone 15 - 2024-06-27 at 17 02 51](https://github.com/Unshut-Labs/converse-app/assets/23103150/4c6667c4-0214-40a9-b925-8229e0280af4)
![Simulator Screenshot - iPhone 15 - 2024-06-27 at 17 02 33](https://github.com/Unshut-Labs/converse-app/assets/23103150/0ded8438-daf3-4a43-887e-fbd8765192d8)
![Simulator Screenshot - iPhone 15 Plus - 2024-06-27 at 17 01 46](https://github.com/Unshut-Labs/converse-app/assets/23103150/b623c40e-9ee9-47ed-88e0-ee4a2ba3336a)
