### PR TITLE
Recycle frames & images with the same aspect ratio

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -333,6 +333,17 @@ export default function Chat() {
                 return `FRAME-${
                   frame?.frameInfo?.image?.aspectRatio || "1.91.1"
                 }`;
+              } else if (
+                (isContentType("attachment", item.contentType) ||
+                  isContentType("remoteAttachment", item.contentType)) &&
+                item.converseMetadata?.attachment?.size?.height &&
+                item.converseMetadata?.attachment?.size?.width
+              ) {
+                const aspectRatio = (
+                  item.converseMetadata.attachment.size.width /
+                  item.converseMetadata.attachment.size.height
+                ).toFixed(2);
+                return `ATTACHMENT-${aspectRatio}`;
               } else {
                 return item.contentType;
               }


### PR DESCRIPTION
New approach to fix some jumpy scrolling
I noticed that images were less jumpy than frames and that's probably because of the `getItemType` method that reuses image cells
Trying that approach because `overrideItemLayout` will be hard to code especially the # of lines of a message will depend on screen settings, system font & font size, etc.

Again, since in debug mode FlashList is not performant, waiting for this to be integrated in a preview build to see what issues remain.
