### PR TITLE
fix alignment of replied-to sender name

### DIFF
--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -474,8 +474,6 @@ const useStyles = () => {
       paddingVertical: 10,
       marginTop: 10,
       marginHorizontal: 10,
-      flexDirection: "column",
-      alignItems: "flex-start",
     },
     innerBubbleMe: {
       backgroundColor: myMessageInnerBubbleColor(colorScheme),
@@ -521,7 +519,6 @@ const useStyles = () => {
       fontSize: 12,
       marginBottom: 4,
       color: "white",
-      justifyContent: "flex-start",
       paddingVertical: 0,
       paddingHorizontal: 0,
     },


### PR DESCRIPTION
Fixes #193 . Name should be in bubble, but left-justified.