### PR TITLE
fix: remove warning introduced by context overflow

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -401,16 +401,13 @@ const useStyles = () => {
       flex: 1,
       justifyContent: "flex-end",
       backgroundColor: backgroundColor(colorScheme),
-      overflow: "visible",
     },
     chatContent: {
       backgroundColor: backgroundColor(colorScheme),
       flex: 1,
-      overflow: "visible",
     },
     chat: {
       backgroundColor: backgroundColor(colorScheme),
-      overflow: "visible",
     },
     inputBottomFiller: {
       position: "absolute",

--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -481,7 +481,6 @@ const useStyles = () => {
     messageRow: {
       flexDirection: "row",
       flexWrap: "wrap",
-      overflow: "visible",
     },
     messageSwipeable: {
       width: "100%",
@@ -493,7 +492,6 @@ const useStyles = () => {
       width: "100%",
       flexDirection: "row",
       flexWrap: "wrap",
-      overflow: "visible",
     },
     statusContainer: {
       marginLeft: "auto",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1742,7 +1742,7 @@ SPEC CHECKSUMS:
   CoinbaseWalletSDK: ea1f37512bbc69ebe07416e3b29bf840f5cc3152
   CoinbaseWalletSDKExpo: fc6cc756974827763d7a0decf7140c2902dafca2
   Connect-Swift: 1de2ef4a548c59ecaeb9120812dfe0d6e07a0d47
-  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
+  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   EASClient: a42ee8bf36c93b3128352faf2ae49405ab4f80bd
   EXApplication: 16bcea16789221bd566e64b5ea2608cf7756b005
   EXConstants: a5f6276e565d98f9eb4280f81241fc342d641590
@@ -1782,7 +1782,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 9f2b8b243131565335437dba74923a8d3015e780
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   GenericJSON: 79a840eeb77030962e8cf02a62d36bd413b67626
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
   GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
   hermes-engine: 9cecf9953a681df7556b8cc9c74905de8f3293c0
   libaom: 144606b1da4b5915a1054383c3a4459ccdb3c661


### PR DESCRIPTION
Remove annoying warning introduced by some styling props