### PR TITLE
fix jumping message status after sending message

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -88,7 +88,8 @@ const getListArray = (
         message.dateChange =
           differenceInCalendarDays(message.sent, previousMessage.sent) > 0;
         if (
-          previousMessage.senderAddress === message.senderAddress &&
+          previousMessage.senderAddress.toLowerCase() ===
+            message.senderAddress.toLowerCase() &&
           !message.dateChange &&
           !isContentType("groupUpdated", previousMessage.contentType)
         ) {
@@ -107,7 +108,8 @@ const getListArray = (
         const nextMessageDateChange =
           differenceInCalendarDays(nextMessage.sent, message.sent) > 0;
         if (
-          nextMessage.senderAddress === message.senderAddress &&
+          nextMessage.senderAddress.toLowerCase() ===
+            message.senderAddress.toLowerCase() &&
           !nextMessageDateChange &&
           !isContentType("groupUpdated", nextMessage.contentType)
         ) {

--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -163,6 +163,8 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
 
   const reactions = getMessageReactions(message);
   const showInBubble = !isGroupUpdated;
+  const showAvatar = isGroup && !message.fromMe;
+  const showStatus = message.fromMe && !message.hasNextMessageInSeries;
 
   // maybe using useChatStore inside ChatMessage
   // leads to bad perf? Let's be cautious
@@ -258,9 +260,7 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
               alignItems: "flex-end",
             }}
           >
-            {isGroup && !message.fromMe && (
-              <MessageSenderAvatar message={message} />
-            )}
+            {showAvatar && <MessageSenderAvatar message={message} />}
             <View style={{ flex: 1 }}>
               {isGroup &&
                 !message.fromMe &&
@@ -269,6 +269,7 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
               <View
                 style={{
                   alignSelf: message.fromMe ? "flex-end" : "flex-start",
+                  alignItems: message.fromMe ? "flex-end" : "flex-start",
                 }}
               >
                 <ChatMessageActions
@@ -382,7 +383,7 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
                       </Text>
                     </TouchableOpacity>
                   )}
-                  {!message.hasNextMessageInSeries && message.fromMe && (
+                  {showStatus && (
                     <View
                       style={[
                         styles.statusContainer,


### PR DESCRIPTION
This fixes #215, which results from different casing used on the senderAddress for the optimistic pending group message.