### PR TITLE
always show quoted message sender name in replies

### DIFF
--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -21,6 +21,9 @@ import {
 } from "react-native";
 import { Swipeable } from "react-native-gesture-handler";
 
+import ChatMessageActions from "./MessageActions";
+import ChatMessageReactions from "./MessageReactions";
+import MessageStatus from "./MessageStatus";
 import {
   currentAccount,
   useChatStore,
@@ -54,9 +57,6 @@ import ChatGroupUpdatedMessage from "../ChatGroupUpdatedMessage";
 import FramesPreviews from "../Frame/FramesPreviews";
 import ChatInputReplyBubble from "../Input/InputReplyBubble";
 import TransactionPreview from "../Transaction/TransactionPreview";
-import ChatMessageActions from "./MessageActions";
-import ChatMessageReactions from "./MessageReactions";
-import MessageStatus from "./MessageStatus";
 
 export type MessageToDisplay = XmtpMessage & {
   hasPreviousMessageInSeries: boolean;
@@ -301,17 +301,15 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
                           }, 350);
                         }}
                       >
-                        {!message.fromMe && (
-                          <Text
-                            style={[
-                              styles.messageText,
-                              message.fromMe ? styles.messageTextMe : undefined,
-                              styles.replyToUsername,
-                            ]}
-                          >
-                            {replyingToProfileName}
-                          </Text>
-                        )}
+                        <Text
+                          style={[
+                            styles.messageText,
+                            styles.replyToUsername,
+                            message.fromMe ? styles.messageTextMe : undefined,
+                          ]}
+                        >
+                          {replyingToProfileName}
+                        </Text>
                         <ChatInputReplyBubble
                           replyingToMessage={replyingToMessage}
                           fromMe={message.fromMe}


### PR DESCRIPTION
Contrary to designs, per @darickdang we do NOT want to hide the quoted message sender name in reply messages from the user.