### PR TITLE
fix: android building and using same encryption key in notifications & RN

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
@@ -10,6 +10,12 @@
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
   <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
+  <!-- This forces minSdkVersion 23 for module reactnativeaesgcmcrypto even if the lib
+   has minSdkVersion 26. It could technically lead to failures but we don't care as it's
+   a dependency in thirdweb used only for inapp wallets which we don't care about -->
+  <uses-sdk
+      android:minSdkVersion="23"
+      tools:overrideLibrary="com.reactnativeaesgcmcrypto" />
   <queries>
     <package android:name="org.toshi"/>
     <intent>

--- a/android/app/src/main/java/com/converse/dev/xmtp/Client.kt
+++ b/android/app/src/main/java/com/converse/dev/xmtp/Client.kt
@@ -36,16 +36,12 @@ fun getXmtpKeyForAccount(appContext: Context, account: String): String? {
     return null
 }
 
-fun base64ToSubarray(base64Key: String): ByteArray? {
-    return try {
-        // Decode the base64 string
-        val data = Base64.decode(base64Key)
-
-        // Get the subarray of the first 32 bytes
-        data.take(32).toByteArray()
-    } catch (e: IllegalArgumentException) {
-        // Return null if the base64 string is invalid
-        null
+fun getDbEncryptionKey(): ByteArray? {
+    val key = getKeychainValue("LIBXMTP_DB_ENCRYPTION_KEY")
+    if (key != null) {
+        return Base64.decode(key, Base64.DEFAULT)
+    } else {
+        throw Exception("No db encryption key found")
     }
 }
 
@@ -63,8 +59,7 @@ fun getXmtpClient(appContext: Context, account: String): Client? {
         if (xmtpEnvString == "production") XMTPEnvironment.PRODUCTION else XMTPEnvironment.DEV
 
     val dbDirectory = "/data/data/${appContext.packageName}/databases"
-
-    val dbEncryptionKey = base64ToSubarray(keyString)
+    val dbEncryptionKey = getDbEncryptionKey()
 
     val options = ClientOptions(api = ClientOptions.Api(env = xmtpEnv, isSecure = true), enableV3 = true, dbEncryptionKey = dbEncryptionKey,  dbDirectory = dbDirectory, appContext = appContext)
 

--- a/components/Chat/Message/MessageStatus.tsx
+++ b/components/Chat/Message/MessageStatus.tsx
@@ -96,7 +96,7 @@ const useStyles = () => {
       overflow: "hidden",
     },
     contentContainer: {
-      paddingVertical: 5,
+      paddingTop: 5,
     },
     statusText: {
       fontSize: 12,

--- a/ios/ConverseNotificationExtension/Xmtp/Client.swift
+++ b/ios/ConverseNotificationExtension/Xmtp/Client.swift
@@ -27,18 +27,18 @@ func getXmtpKeyForAccount(account: String) throws -> String? {
   return accountKey!
 }
 
-func base64ToSubarray(base64Key: String) -> Data? {
-    // Decode the base64 string
-    guard let data = Data(base64Encoded: base64Key) else {
-        return nil
+func getDbEncryptionKey() throws -> Data {
+  if let key = getKeychainValue(forKey: "LIBXMTP_DB_ENCRYPTION_KEY") {
+        if let keyData = Data(base64Encoded: key) {
+            return keyData
+        } else {
+          throw "Unable to decode base64 key"
+        }
+    } else {
+      throw "No db encryption key found"
     }
-    
-    // Get the subarray of the first 'length' bytes
-    let subarray = data.prefix(32)
-          
-    // Convert the subarray to Data
-    return Data(subarray)
 }
+
 
 func getXmtpClient(account: String) async -> XMTP.Client? {
   do {
@@ -50,7 +50,7 @@ func getXmtpClient(account: String) async -> XMTP.Client? {
     if (xmtpKeyData == nil) {
       return nil;
     }
-    let encryptionKey = base64ToSubarray(base64Key: xmtpKey!)
+    let encryptionKey = try! getDbEncryptionKey()
     let privateKeyBundle = try! PrivateKeyBundle(serializedData: xmtpKeyData!)
     let xmtpEnv = getXmtpEnv()
     


### PR DESCRIPTION
I noticed I never upgraded the notifications extensions to use the global secure enclave-stored single key that I introduced in https://github.com/Unshut-Labs/converse-app/pull/256/files

We never noticed it because it was not failing on iOS, which is an issue as maybe the encryption key is not used somehow? Opened an issue here: https://github.com/xmtp/xmtp-react-native/pull/441/files