### PR TITLE
Mitigate unpredictable animation wonkiness in "sent" indicator

### DIFF
--- a/components/Chat/Message/MessageActions.tsx
+++ b/components/Chat/Message/MessageActions.tsx
@@ -295,13 +295,13 @@ export default function ChatMessageActions({
   const [hasAnimatedIn, setHasAnimatedIn] = useState(false);
 
   const opacity = useSharedValue(0);
-  const scale = useSharedValue(0);
+  const scale = useSharedValue(0.7);
   const translateY = useSharedValue(20);
 
   useEffect(() => {
     if (shouldAnimateIn && !hasAnimatedIn) {
       opacity.value = 0;
-      scale.value = 0;
+      scale.value = 0.7;
       translateY.value = 20;
 
       const timingConfig = {


### PR DESCRIPTION
There are occasional issues with the entrance animation for the "Sent" indicator that I haven't been able to reliably reproduce.
- Sometimes the animation makes the text really small.
- Sometimes the animation does not even play.
At least in the simulator, I can get rid of these issues by introducing a healthy delay for async state updates to sort themselves out.

This PR also tweaks the the message bubble entrance animation to be less extreme for large bubbles.

Closes #299 .