### PR TITLE
make Add group member button more tappable

### DIFF
--- a/screens/NewConversation/NewConversation.tsx
+++ b/screens/NewConversation/NewConversation.tsx
@@ -117,6 +117,7 @@ export default function NewConversation({
                 variant="text"
                 title={route.params?.addingToGroupTopic ? "Add" : "Next"}
                 onPress={handleRightAction}
+                style={{ marginRight: -10, padding: 10 }}
               />
             );
           }


### PR DESCRIPTION
- #292 
The button only requires one tap, but the word "Add" is small and hard to hit, so it just needed some padding.

<img src="https://github.com/user-attachments/assets/8b88deb7-4a41-4e32-9bd8-3d771795614c" width=350 />
