### PR TITLE
fix: iOS sqlite encryption

### DIFF
--- a/ios/Converse.xcodeproj/project.pbxproj
+++ b/ios/Converse.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		487B0810AD42146275EB9AC9 /* Pods_ConverseNotificationExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE2E0F0BA0DFC0EE97DBE0EE /* Pods_ConverseNotificationExtension.framework */; };
 		4C2440D02A9C8BE8004F31A3 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2440CF2A9C8BE8004F31A3 /* Keychain.swift */; };
 		4C2440D22A9C8C5A004F31A3 /* Datatypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2440D12A9C8C5A004F31A3 /* Datatypes.swift */; };
 		4C2440D42A9C8CFE004F31A3 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2440D32A9C8CFE004F31A3 /* Client.swift */; };
@@ -27,12 +28,11 @@
 		4CFB3F322BCE878300A47FFE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 4CFB3F312BCE876A00A47FFE /* PrivacyInfo.xcprivacy */; };
 		4CFB3F332BCE878A00A47FFE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 4CFB3F312BCE876A00A47FFE /* PrivacyInfo.xcprivacy */; };
 		6821E5F22C2B2A620051F947 /* Spam.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6821E5F12C2B2A620051F947 /* Spam.swift */; };
-		9075F7ED8DD224A49926DAA1 /* Pods_Converse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A60FA9F79ECEAE8E341071C /* Pods_Converse.framework */; };
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		B7969B4A79FE4F9F8C52019D /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FED7E170C7437EB719C8C6 /* noop-file.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		DA84913A2AD94AED00288FE0 /* NotificationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8491392AD94AED00288FE0 /* NotificationUtils.swift */; };
-		F58EA8305884ED6DF0BDF78D /* Pods_ConverseNotificationExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 205EAD7021331DF97121D96C /* Pods_ConverseNotificationExtension.framework */; };
+		EC539CA93BEE17CA12EC223F /* Pods_Converse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B07EB2401FC5C17B8328387 /* Pods_Converse.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,16 +60,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		000A3CED54C850EE71144470 /* Pods-Converse.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Converse.debug.xcconfig"; path = "Target Support Files/Pods-Converse/Pods-Converse.debug.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Converse.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Converse.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = Converse/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = Converse/AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Converse/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Converse/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Converse/main.m; sourceTree = "<group>"; };
-		1445CF94083F9D9607454340 /* Pods-ConverseNotificationExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ConverseNotificationExtension.release.xcconfig"; path = "Target Support Files/Pods-ConverseNotificationExtension/Pods-ConverseNotificationExtension.release.xcconfig"; sourceTree = "<group>"; };
-		205EAD7021331DF97121D96C /* Pods_ConverseNotificationExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ConverseNotificationExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3A60FA9F79ECEAE8E341071C /* Pods_Converse.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Converse.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1B07EB2401FC5C17B8328387 /* Pods_Converse.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Converse.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1DE44E2DAA783EFD28AA1BAA /* Pods-Converse.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Converse.debug.xcconfig"; path = "Target Support Files/Pods-Converse/Pods-Converse.debug.xcconfig"; sourceTree = "<group>"; };
 		4C2440CF2A9C8BE8004F31A3 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		4C2440D12A9C8C5A004F31A3 /* Datatypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Datatypes.swift; sourceTree = "<group>"; };
 		4C2440D32A9C8CFE004F31A3 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
@@ -77,6 +75,7 @@
 		4C2440D82A9C8D5C004F31A3 /* Messages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Messages.swift; sourceTree = "<group>"; };
 		4C2440DA2A9C8E30004F31A3 /* MMKV.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MMKV.swift; sourceTree = "<group>"; };
 		4C2440DC2A9C9006004F31A3 /* SQLite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLite.swift; sourceTree = "<group>"; };
+		4C3DA9DC2C4A5196002FBC5A /* SQLCipher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SQLCipher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C3F6104295C9038007A969B /* ConverseNotificationExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ConverseNotificationExtension.entitlements; sourceTree = "<group>"; };
 		4C65044A295C7C1F00C5A40F /* ConverseNotificationExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ConverseNotificationExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C65044C295C7C1F00C5A40F /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
@@ -85,13 +84,15 @@
 		4CBD67172A9CF7C30010C648 /* Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sentry.swift; sourceTree = "<group>"; };
 		4CBD671B2A9D08050010C648 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		4CFB3F312BCE876A00A47FFE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		57DF16B8A3E6E35F362AB6BA /* Pods-Converse.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Converse.release.xcconfig"; path = "Target Support Files/Pods-Converse/Pods-Converse.release.xcconfig"; sourceTree = "<group>"; };
 		6821E5F12C2B2A620051F947 /* Spam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spam.swift; sourceTree = "<group>"; };
 		68FED7E170C7437EB719C8C6 /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "Converse/noop-file.swift"; sourceTree = "<group>"; };
-		719365A4F39A103E17CDA8CF /* Pods-Converse.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Converse.release.xcconfig"; path = "Target Support Files/Pods-Converse/Pods-Converse.release.xcconfig"; sourceTree = "<group>"; };
+		8D8D30A3ADBD96E76A31B9DF /* Pods-ConverseNotificationExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ConverseNotificationExtension.release.xcconfig"; path = "Target Support Files/Pods-ConverseNotificationExtension/Pods-ConverseNotificationExtension.release.xcconfig"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Converse/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
-		D1C50CFE219D5A0A7A8098B5 /* Pods-ConverseNotificationExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ConverseNotificationExtension.debug.xcconfig"; path = "Target Support Files/Pods-ConverseNotificationExtension/Pods-ConverseNotificationExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		CE2E0F0BA0DFC0EE97DBE0EE /* Pods_ConverseNotificationExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ConverseNotificationExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA8491392AD94AED00288FE0 /* NotificationUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationUtils.swift; sourceTree = "<group>"; };
+		E493E7650536B00346567A4B /* Pods-ConverseNotificationExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ConverseNotificationExtension.debug.xcconfig"; path = "Target Support Files/Pods-ConverseNotificationExtension/Pods-ConverseNotificationExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Converse/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -101,7 +102,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9075F7ED8DD224A49926DAA1 /* Pods_Converse.framework in Frameworks */,
+				EC539CA93BEE17CA12EC223F /* Pods_Converse.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -110,7 +111,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C31F4EE29AF887B0032D062 /* Alamofire in Frameworks */,
-				F58EA8305884ED6DF0BDF78D /* Pods_ConverseNotificationExtension.framework in Frameworks */,
+				487B0810AD42146275EB9AC9 /* Pods_ConverseNotificationExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -136,9 +137,10 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4C3DA9DC2C4A5196002FBC5A /* SQLCipher.framework */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				3A60FA9F79ECEAE8E341071C /* Pods_Converse.framework */,
-				205EAD7021331DF97121D96C /* Pods_ConverseNotificationExtension.framework */,
+				1B07EB2401FC5C17B8328387 /* Pods_Converse.framework */,
+				CE2E0F0BA0DFC0EE97DBE0EE /* Pods_ConverseNotificationExtension.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -225,10 +227,10 @@
 		D65327D7A22EEC0BE12398D9 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				000A3CED54C850EE71144470 /* Pods-Converse.debug.xcconfig */,
-				719365A4F39A103E17CDA8CF /* Pods-Converse.release.xcconfig */,
-				D1C50CFE219D5A0A7A8098B5 /* Pods-ConverseNotificationExtension.debug.xcconfig */,
-				1445CF94083F9D9607454340 /* Pods-ConverseNotificationExtension.release.xcconfig */,
+				1DE44E2DAA783EFD28AA1BAA /* Pods-Converse.debug.xcconfig */,
+				57DF16B8A3E6E35F362AB6BA /* Pods-Converse.release.xcconfig */,
+				E493E7650536B00346567A4B /* Pods-ConverseNotificationExtension.debug.xcconfig */,
+				8D8D30A3ADBD96E76A31B9DF /* Pods-ConverseNotificationExtension.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -248,7 +250,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "Converse" */;
 			buildPhases = (
-				87B65BC22A20E255EFBC3706 /* [CP] Check Pods Manifest.lock */,
+				A684B2EB4F6DF6C4F9CB7BE6 /* [CP] Check Pods Manifest.lock */,
 				C4304E4C15B6A588EF0F2290 /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
@@ -256,8 +258,8 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				BADF501E92C64E5B8BE5C54D /* Upload Debug Symbols to Sentry */,
 				4C650452295C7C1F00C5A40F /* Embed Foundation Extensions */,
-				E77124006398F213A9B2B887 /* [CP] Embed Pods Frameworks */,
-				950B8C24E47BF20C9F204515 /* [CP] Copy Pods Resources */,
+				EA09FE8A63287BE4CBBD6AC2 /* [CP] Embed Pods Frameworks */,
+				8AF3DF030C385B11555F7C00 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -273,11 +275,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4C650455295C7C1F00C5A40F /* Build configuration list for PBXNativeTarget "ConverseNotificationExtension" */;
 			buildPhases = (
-				33B7BB1240A8B27013DBBDC1 /* [CP] Check Pods Manifest.lock */,
+				3FD844CBEC76410D149BCA50 /* [CP] Check Pods Manifest.lock */,
 				4C650446295C7C1F00C5A40F /* Sources */,
 				4C650447295C7C1F00C5A40F /* Frameworks */,
 				4C650448295C7C1F00C5A40F /* Resources */,
-				9A59CB24F8B33E7377CBE29F /* [CP] Copy Pods Resources */,
+				42C973EFEDDABBB30B974BBF /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -368,7 +370,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n# Source .xcode.env.updates if it exists to allow\n# SKIP_BUNDLING to be unset if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\n# Source local changes to allow overrides\n# if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n/bin/sh `\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'\"` `\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
 		};
-		33B7BB1240A8B27013DBBDC1 /* [CP] Check Pods Manifest.lock */ = {
+		3FD844CBEC76410D149BCA50 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -390,29 +392,27 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		87B65BC22A20E255EFBC3706 /* [CP] Check Pods Manifest.lock */ = {
+		42C973EFEDDABBB30B974BBF /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
+				"${PODS_ROOT}/Target Support Files/Pods-ConverseNotificationExtension/Pods-ConverseNotificationExtension-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Sentry/Sentry.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/SQLite.swift/SQLite.swift.bundle",
 			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Converse-checkManifestLockResult.txt",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Sentry.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SQLite.swift.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ConverseNotificationExtension/Pods-ConverseNotificationExtension-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		950B8C24E47BF20C9F204515 /* [CP] Copy Pods Resources */ = {
+		8AF3DF030C385B11555F7C00 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -432,6 +432,7 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/ReachabilitySwift/ReachabilitySwift.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/SDWebImage/SDWebImage.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/SQLCipher/SQLCipher.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Sentry/Sentry.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-launcher/EXDevLauncher.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-menu/EXDevMenu.bundle",
@@ -451,6 +452,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReachabilitySwift.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SDWebImage.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SQLCipher.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Sentry.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevLauncher.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevMenu.bundle",
@@ -460,24 +462,26 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Converse/Pods-Converse-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		9A59CB24F8B33E7377CBE29F /* [CP] Copy Pods Resources */ = {
+		A684B2EB4F6DF6C4F9CB7BE6 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ConverseNotificationExtension/Pods-ConverseNotificationExtension-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/Sentry/Sentry.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/SQLite.swift/SQLite.swift.bundle",
+			inputFileListPaths = (
 			);
-			name = "[CP] Copy Pods Resources";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Sentry.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SQLite.swift.bundle",
+				"$(DERIVED_FILE_DIR)/Pods-Converse-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ConverseNotificationExtension/Pods-ConverseNotificationExtension-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		BADF501E92C64E5B8BE5C54D /* Upload Debug Symbols to Sentry */ = {
@@ -513,7 +517,7 @@
 			shellPath = /bin/sh;
 			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-Converse/expo-configure-project.sh\"\n";
 		};
-		E77124006398F213A9B2B887 /* [CP] Embed Pods Frameworks */ = {
+		EA09FE8A63287BE4CBBD6AC2 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -586,7 +590,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000A3CED54C850EE71144470 /* Pods-Converse.debug.xcconfig */;
+			baseConfigurationReference = 1DE44E2DAA783EFD28AA1BAA /* Pods-Converse.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconPreview;
@@ -628,7 +632,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 719365A4F39A103E17CDA8CF /* Pods-Converse.release.xcconfig */;
+			baseConfigurationReference = 57DF16B8A3E6E35F362AB6BA /* Pods-Converse.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconPreview;
@@ -664,7 +668,7 @@
 		};
 		4C650453295C7C1F00C5A40F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D1C50CFE219D5A0A7A8098B5 /* Pods-ConverseNotificationExtension.debug.xcconfig */;
+			baseConfigurationReference = E493E7650536B00346567A4B /* Pods-ConverseNotificationExtension.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -708,7 +712,7 @@
 		};
 		4C650454295C7C1F00C5A40F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1445CF94083F9D9607454340 /* Pods-ConverseNotificationExtension.release.xcconfig */;
+			baseConfigurationReference = 8D8D30A3ADBD96E76A31B9DF /* Pods-ConverseNotificationExtension.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -17,7 +17,7 @@ install! 'cocoapods',
 
 
 # Version must match version from XMTP Podspec (matching @xmtp/react-native-sdk from package.json)
-# https://github.com/xmtp/xmtp-react-native/blob/v1.34.0-beta.22/ios/XMTPReactNative.podspec#L29
+# https://github.com/xmtp/xmtp-react-native/blob/v1.34.0-beta.23/ios/XMTPReactNative.podspec#L29
 $xmtpVersion = '0.13.6'
 
 # Pinning MMKV to 1.3.3 that has included that fix https://github.com/Tencent/MMKV/pull/1222#issuecomment-1905164314

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -389,6 +389,7 @@ PODS:
     - MMKVCore (~> 1.3.3)
   - MMKVCore (1.3.3)
   - op-sqlite (6.0.1):
+    - OpenSSL-Universal
     - React
     - React-callinvoker
     - React-Core
@@ -1761,6 +1762,11 @@ PODS:
   - secp256k1.swift (0.1.4)
   - Sentry/HybridSDK (8.29.1)
   - SocketRocket (0.7.0)
+  - SQLCipher (4.6.0):
+    - SQLCipher/standard (= 4.6.0)
+  - SQLCipher/common (4.6.0)
+  - SQLCipher/standard (4.6.0):
+    - SQLCipher/common
   - SQLite.swift (0.15.3):
     - SQLite.swift/standard (= 0.15.3)
   - SQLite.swift/standard (0.15.3)
@@ -1779,10 +1785,11 @@ PODS:
     - GzipSwift
     - LibXMTP (= 0.5.4-beta4)
     - web3.swift
-  - XMTPReactNative (1.34.0-beta.22):
+  - XMTPReactNative (1.34.0-beta.23):
     - ExpoModulesCore
     - MessagePacker
     - secp256k1.swift
+    - SQLCipher
     - XMTP (= 0.13.6)
   - Yoga (0.0.0)
 
@@ -1944,6 +1951,7 @@ SPEC REPOS:
     - secp256k1.swift
     - Sentry
     - SocketRocket
+    - SQLCipher
     - SQLite.swift
     - sqlite3
     - SwiftProtobuf
@@ -2255,7 +2263,7 @@ SPEC CHECKSUMS:
   MMKV: f902fb6719da13c2ab0965233d8963a59416f911
   MMKVAppExtension: fcf23c6b250cc87db63507bc57be8e6ed378168d
   MMKVCore: d26e4d3edd5cb8588c2569222cbd8be4231374e9
-  op-sqlite: 1ca30186b8d062cd451f1d999c691caf151d13e2
+  op-sqlite: 7720c6cc59e76c983263edc07420e642b45fa288
   OpenSSL-Universal: 6e1ae0555546e604dbc632a2b9a24a9c46c41ef6
   RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
   RCTDeprecation: 4c7eeb42be0b2e95195563c49be08d0b839d22b4
@@ -2340,15 +2348,16 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   Sentry: c446963245407030e17f1b926a83c6337dc99f4e
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
+  SQLCipher: 30a8e81afa6128e600b17ffa77d0f92fa05ed208
   SQLite.swift: 8d054987f02728cc912b0eb5a9659650573a65a2
   sqlite3: 02d1f07eaaa01f80a1c16b4b31dfcbb3345ee01a
   SwiftProtobuf: 407a385e97fd206c4fbe880cc84123989167e0d1
   UMAppLoader: f17a5ee8e85b536ace0fc254b447a37ed198d57e
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
   XMTP: aeeff5ecac80f7ec9a2ba4f732d439ab600545ed
-  XMTPReactNative: 847dc0282517b1a188c9c5b4be86b5213d191c7d
+  XMTPReactNative: e7f9f40694d162314ff381c694df5c1a7c2df1f7
   Yoga: eed50599a85bd9f6882a9938d118aed6a397db9c
 
-PODFILE CHECKSUM: 25fd451e9d28aaa1fe47e31426a4893d0000393b
+PODFILE CHECKSUM: 735ef1ee72b2cc194a9782322dc5684214130984
 
 COCOAPODS: 1.15.2

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@xmtp/content-type-transaction-reference": "^1.0.3",
     "@xmtp/frames-client": "^0.5.0",
     "@xmtp/proto": "^3.60.0",
-    "@xmtp/react-native-sdk": "^1.34.0-beta.22",
+    "@xmtp/react-native-sdk": "^1.34.0-beta.23",
     "@xmtp/xmtp-js": "11.5.0",
     "amazon-cognito-identity-js": "^6.3.12",
     "axios": "^1.2.1",
@@ -254,5 +254,8 @@
         "@sentry/react-native"
       ]
     }
+  },
+  "op-sqlite": {
+    "sqlcipher": true
   }
 }

--- a/patches/@op-engineering+op-sqlite+6.0.1.patch
+++ b/patches/@op-engineering+op-sqlite+6.0.1.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/@op-engineering/op-sqlite/cpp/bindings.cpp b/node_modules/@op-engineering/op-sqlite/cpp/bindings.cpp
+index 792dbba..d2e02f1 100644
+--- a/node_modules/@op-engineering/op-sqlite/cpp/bindings.cpp
++++ b/node_modules/@op-engineering/op-sqlite/cpp/bindings.cpp
+@@ -72,20 +72,6 @@ void install(jsi::Runtime &rt,
+           options.getProperty(rt, "encryptionKey").asString(rt).utf8(rt);
+     }
+ 
+-#ifdef OP_SQLITE_USE_SQLCIPHER
+-    if (encryptionKey.empty()) {
+-      throw std::runtime_error(
+-          "[OP SQLite] using SQLCipher encryption key is required");
+-    }
+-//      TODO(osp) find a way to display the yellow box from c++
+-#else
+-    // if (!encryptionKey.empty()) {
+-    //   //  RCTLogWarn(@"Your message")
+-    //   throw std::runtime_error("[OP SQLite] SQLCipher is not enabled, "
+-    //                            "encryption key is not allowed");
+-    // }
+-#endif
+-
+     if (!location.empty()) {
+       if (location == ":memory:") {
+         path = ":memory:";

--- a/yarn.lock
+++ b/yarn.lock
@@ -9390,10 +9390,10 @@
     rxjs "^7.8.0"
     undici "^5.8.1"
 
-"@xmtp/react-native-sdk@^1.34.0-beta.22":
-  version "1.34.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@xmtp/react-native-sdk/-/react-native-sdk-1.34.0-beta.22.tgz#c8e0c5ac3d3837d628184b47754e096e4d87551b"
-  integrity sha512-3mt7hhHxFO7bgY5U9pyjCggUd4FpnSznmgE8WyaNFDYVJuOH16HfYLC0ismoJd6AZptLd23tOo/YVJS1qPhyyQ==
+"@xmtp/react-native-sdk@^1.34.0-beta.23":
+  version "1.34.0-beta.23"
+  resolved "https://registry.yarnpkg.com/@xmtp/react-native-sdk/-/react-native-sdk-1.34.0-beta.23.tgz#09ba55425f1e98264494769844b26dfd5604381f"
+  integrity sha512-EJwoR7GJtFG8wdKqDs/YNwmj3NiOiJOgRF6pqXzQJpOWUVVdtc41JvrrexFoCKFxSYUMniUpr5eLetfFxNFVAA==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@msgpack/msgpack" "^3.0.0-beta2"


### PR DESCRIPTION
libxmtp on iOS RN app seems to be using an external sqlite version and not a bundled one (i.e. it uses the first one that is linked)
Since Converse is itself using other packages  (op-sqlite) that come bundled with an sqlite version (to have the same sqlite features on all devices), it is important that this sqlite version be sqlcipher (it was not)

Waiting for libxmtp team to confirm if we could make sure libxmtp uses a bundled version of sqlcipher. I thought it did because of [this line](https://github.com/xmtp/libxmtp/blob/2de056e0cdf0805c20f2ab938cd362da1c7d4572/xmtp_mls/Cargo.toml#L14)

If it's not possible then this makes sure that
- op-sqlite uses the sqlcipher version
- we can still use it for the converse db without an encryption key (by patching the package). We could also just encrypt the local converse database if we force everyone to logout, we can discuss