### PR TITLE
feat: tappable reaction pile-ons

### DIFF
--- a/components/Chat/Message/MessageActions.tsx
+++ b/components/Chat/Message/MessageActions.tsx
@@ -57,7 +57,7 @@ type Props = {
   children: React.ReactNode;
   message: MessageToDisplay;
   reactions: {
-    [senderAddress: string]: MessageReaction | undefined;
+    [senderAddress: string]: MessageReaction[];
   };
   hideBackground: boolean;
 };
@@ -168,14 +168,15 @@ export default function ChatMessageActions({
 
   const [selectedEmojis, setSelectedEmojis] = useState<string[]>([]);
   useEffect(() => {
-    const myReaction = reactions[userAddress];
-    const newSelectedEmojis = [];
-    if (myReaction && myReaction.schema === "unicode") {
-      const emojiName = getEmojiName(myReaction.content);
-      if (emojiName) {
-        newSelectedEmojis.push(emojiName);
-      }
-    }
+    const myReactions = reactions[userAddress] || [];
+    const newSelectedEmojis = Array.from(
+      new Set(
+        myReactions
+          .filter((reaction) => reaction.schema === "unicode")
+          .map((reaction) => getEmojiName(reaction.content))
+          .filter((emojiName): emojiName is string => emojiName !== null)
+      )
+    );
     setSelectedEmojis(newSelectedEmojis);
   }, [reactions, userAddress]);
 
@@ -443,15 +444,6 @@ export default function ChatMessageActions({
           if (e.alreadySelected) {
             removeReactionFromMessage(conversation, message, e.emoji);
           } else {
-            // We want to remove all emojis first
-            const myReaction = reactions[userAddress];
-            if (myReaction && myReaction.schema === "unicode") {
-              removeReactionFromMessage(
-                conversation,
-                message,
-                myReaction.content
-              );
-            }
             addReactionToMessage(conversation, message, e.emoji);
           }
         }}

--- a/data/store/chatStore.ts
+++ b/data/store/chatStore.ts
@@ -327,14 +327,14 @@ export const initChatStore = (account: string) => {
             }),
 
           deleteConversations: (topics) =>
-            set(({ conversations }) => {
-              setImmediate(() => {
-                subscribeToNotifications(account);
-              });
-              return {
-                conversations: omit(conversations, topics),
-              };
-            }),
+            set(
+              ({ conversations }) =>
+                setImmediate(() => {
+                  subscribeToNotifications(account);
+                }) && {
+                  conversations: omit(conversations, topics),
+                }
+            ),
           updateConversationTopic: (oldTopic, conversation) =>
             set((state) => {
               if (oldTopic in state.conversations) {
@@ -493,12 +493,9 @@ export const initChatStore = (account: string) => {
                   if (referencedMessage) {
                     referencedMessage.reactions =
                       referencedMessage.reactions || new Map();
-                    const alreadyReaction = referencedMessage.reactions.get(
-                      message.id
-                    );
-                    if (!alreadyReaction) {
-                      isUpdated = true;
-                      newState.conversations[topic].lastUpdateAt = now();
+                    isUpdated = true;
+                    newState.conversations[topic].lastUpdateAt = now();
+                    if (!referencedMessage.reactions.has(message.id)) {
                       referencedMessage.reactions.set(message.id, message);
                       referencedMessage.lastUpdateAt = now();
                     }


### PR DESCRIPTION
Resolves #294 and addresses related product implications.

- I expect tapping a reaction to +1 it.
- I associate my +1 with a specific emoji, not with the total number of emoji -> counts are separated.
- I expect tapping my reaction to undo it.
- I need to be able to distinguish my reaction from others'.

This will require a light design touch down the line.

![CleanShot 2024-07-24 at 01 34 24@2x](https://github.com/user-attachments/assets/e553a4df-66b6-4dca-b88d-f98078b0e9fa)
