### PR TITLE
fix: broken coinbase auth on android

### DIFF
--- a/android/app/src/main/java/com/converse/dev/PushNotificationsService.kt
+++ b/android/app/src/main/java/com/converse/dev/PushNotificationsService.kt
@@ -109,11 +109,6 @@ class PushNotificationsService : FirebaseMessagingService() {
             return
         }
 
-        val xmtpClient = getXmtpClient(this, notificationData.account) ?: run {
-            Log.d(TAG, "NO XMTP CLIENT FOUND FOR TOPIC ${notificationData.contentTopic}")
-            return
-        }
-
         Log.d(TAG, "INSTANTIATED XMTP CLIENT FOR ${notificationData.contentTopic}")
 
         val encryptedMessageData = Base64.decode(notificationData.message, Base64.NO_WRAP)
@@ -121,10 +116,15 @@ class PushNotificationsService : FirebaseMessagingService() {
 
         var shouldShowNotification = false
         var result = NotificationDataResult()
+        var context = this
 
         // Using IO dispatcher for background work, not blocking the main thread and UI
         serviceScope.launch {
             try {
+                val xmtpClient = getXmtpClient(context, notificationData.account) ?: run {
+                    Log.d(TAG, "NO XMTP CLIENT FOUND FOR TOPIC ${notificationData.contentTopic}")
+                    return@launch
+                }
                 if (isInviteTopic(notificationData.contentTopic)) {
                     Log.d(TAG, "Handling a new conversation notification")
                     val conversation = getNewConversationFromEnvelope(applicationContext, xmtpClient, envelope)

--- a/android/app/src/main/java/com/converse/dev/xmtp/Client.kt
+++ b/android/app/src/main/java/com/converse/dev/xmtp/Client.kt
@@ -45,7 +45,7 @@ fun getDbEncryptionKey(): ByteArray? {
     }
 }
 
-fun getXmtpClient(appContext: Context, account: String): Client? {
+suspend fun getXmtpClient(appContext: Context, account: String): Client? {
     val keyString = getXmtpKeyForAccount(appContext, account) ?: return null
     val keyByteArray = Base64.decode(keyString)
     val keys = PrivateKeyBundleV1Builder.buildFromBundle(keyByteArray)

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -17,8 +17,8 @@ install! 'cocoapods',
 
 
 # Version must match version from XMTP Podspec (matching @xmtp/react-native-sdk from package.json)
-# https://github.com/xmtp/xmtp-react-native/blob/v1.34.0-beta.24/ios/XMTPReactNative.podspec#L29
-$xmtpVersion = '0.13.7'
+# https://github.com/xmtp/xmtp-react-native/blob/v2.0.0/ios/XMTPReactNative.podspec#L29
+$xmtpVersion = '0.13.8'
 
 # Pinning MMKV to 1.3.3 that has included that fix https://github.com/Tencent/MMKV/pull/1222#issuecomment-1905164314
 $mmkvVersion = '1.3.3'

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@xmtp/content-type-transaction-reference": "^1.0.3",
     "@xmtp/frames-client": "^0.5.0",
     "@xmtp/proto": "^3.60.0",
-    "@xmtp/react-native-sdk": "^1.34.0-beta.24",
+    "@xmtp/react-native-sdk": "^2.0.0",
     "@xmtp/xmtp-js": "11.5.0",
     "amazon-cognito-identity-js": "^6.3.12",
     "axios": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6128,14 +6128,15 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-11.3.1.tgz#4539371a2f4bd402d932031be82c2449ed63a1a5"
   integrity sha512-UBnJxyV0b7i9Moa97Av+HKho1ByzX0DtbJXzUQS5E3xhQs6P2D/Os0iw3ouy7joY1TVd6uIhplPbr7l1SJNaNQ==
 
-"@react-native/assets-registry@0.74.85":
-  version "0.74.85"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.74.85.tgz#ae903c0c25f4d6a751d53d63245d5612c81edd98"
-  integrity sha512-59YmIQxfGDw4aP9S/nAM+sjSFdW8fUP6fsqczCcXgL2YVEjyER9XCaUT0J1K+PdHep8pi05KUgIKUds8P3jbmA==
 "@react-native-menu/menu@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@react-native-menu/menu/-/menu-1.1.2.tgz#972406d25296a0d01614dc36fae7884c2a08dafd"
   integrity sha512-I7JWiwmIwRp+Tee2OJHPwzVKdLjzgUkdChHQ75oyEWo1YcVsXEjLVGmxWCTA6JExzS6SQW/ACmjuXLJFTvu9Pw==
+
+"@react-native/assets-registry@0.74.85":
+  version "0.74.85"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.74.85.tgz#ae903c0c25f4d6a751d53d63245d5612c81edd98"
+  integrity sha512-59YmIQxfGDw4aP9S/nAM+sjSFdW8fUP6fsqczCcXgL2YVEjyER9XCaUT0J1K+PdHep8pi05KUgIKUds8P3jbmA==
 
 "@react-native/babel-plugin-codegen@0.73.2":
   version "0.73.2"
@@ -9394,10 +9395,10 @@
     rxjs "^7.8.0"
     undici "^5.8.1"
 
-"@xmtp/react-native-sdk@^1.34.0-beta.24":
-  version "1.34.0-beta.24"
-  resolved "https://registry.yarnpkg.com/@xmtp/react-native-sdk/-/react-native-sdk-1.34.0-beta.24.tgz#55083a6006dc5442339f94b54b063c92d80e1b33"
-  integrity sha512-4BVTJjQQF3P7WvRde3OQ7QI0Q2e8BjjDPmsVrEl2W59b8s7QBeU/arnslFyRzv4tOTy7kVIIO2gMGkTO+YTSSw==
+"@xmtp/react-native-sdk@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@xmtp/react-native-sdk/-/react-native-sdk-2.0.0.tgz#8b41b5438f5af7e8d67c339c5b7e9a51b43e8553"
+  integrity sha512-qI2eNclO6S9ijP/H/1bbeuJnhFRx2MPoLpCyOvjSJ8yhWTJuxolwuqd3hI+zHP91xDGiyp6rbgLrQqYhnjqqMw==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@msgpack/msgpack" "^3.0.0-beta2"


### PR DESCRIPTION
Wow, this was a hard one.

The XMTPModule `auth` method was blocking its thread.
But all expo module `AsyncFunction` share the same queue by default!
That means that the thread was blocked but Coinbase SDK was trying to call another AsyncFunction on the same thread and it was waiting in vain.

So we just needed to make the auth method run in a separate thread in Kotlin, which is now the case in the latest SDK version!

Note that I never reproduced the same issue on Metamask