### PR TITLE
fix: db locking during onboarding

### DIFF
--- a/utils/xmtpRN/signIn.ts
+++ b/utils/xmtpRN/signIn.ts
@@ -47,5 +47,8 @@ export const getXmtpBase64KeyFromSigner = async (
     historySyncUrl: config.historySyncUrl,
   });
   const base64Key = await client.exportKeyBundle();
+  // This Client is only be used to extract the key, we can disconnect
+  // it to prevent locks happening during Onboarding
+  await client.dropLocalDatabaseConnection();
   return base64Key;
 };


### PR DESCRIPTION
A tentative fix to prevent db locking from libxmtp during the onboarding process
Could help with the crash part of #356  that @saulmc was experiencing