### PR TITLE
fix: improve shake perf

### DIFF
--- a/utils/shake.ts
+++ b/utils/shake.ts
@@ -1,36 +1,35 @@
-import { Accelerometer, AccelerometerMeasurement } from "expo-sensors";
-import { useState, useEffect } from "react";
+import { Accelerometer } from "expo-sensors";
+import { useEffect, useRef } from "react";
 
-const THRESHOLD = 4; // Adjust this value based on your sensitivity preference
+const THRESHOLD = 3; // Adjust this value based on your sensitivity preference
 const SHAKE_WINDOW = 1000; // Time window for detecting shakes (in milliseconds)
 
 export const useDoOnShake = (onShake: () => void) => {
-  const [data, setData] = useState<AccelerometerMeasurement | undefined>(
-    undefined
-  );
-  const [shakeTimestamp, setShakeTimestamp] = useState(0);
+  const shakeTimestamp = useRef(0);
 
   useEffect(() => {
-    Accelerometer.setUpdateInterval(100);
+    Accelerometer.setUpdateInterval(300);
 
-    const subscription = Accelerometer.addListener((accelerometerData) => {
-      setData(accelerometerData);
+    const subscription = Accelerometer.addListener((data) => {
+      if (!data) return;
+
+      const handleShake = () => {
+        const { x, y, z } = data;
+        const acceleration = Math.abs(x) + Math.abs(y) + Math.abs(z);
+
+        if (acceleration >= THRESHOLD) {
+          const now = Date.now();
+          if (now - shakeTimestamp.current > SHAKE_WINDOW) {
+            onShake();
+            shakeTimestamp.current = now;
+          }
+        }
+      };
+
+      const id = requestAnimationFrame(handleShake);
+      return () => cancelAnimationFrame(id);
     });
 
     return () => subscription.remove();
-  }, []);
-
-  useEffect(() => {
-    if (!data) return;
-    const { x, y, z } = data;
-    const acceleration = Math.sqrt(x * x + y * y + z * z);
-
-    if (acceleration >= THRESHOLD) {
-      const now = Date.now();
-      if (now - shakeTimestamp > SHAKE_WINDOW) {
-        onShake();
-        setShakeTimestamp(now);
-      }
-    }
-  }, [data, onShake, shakeTimestamp]);
+  }, [onShake]);
 };


### PR DESCRIPTION
The current shake detector seems to be killing perf
Never managed to make [react-native-shake](https://github.com/Doko-Demo-Doa/react-native-shake) work. Too bad because it's on the native thread

So trying in this PR to improve the current JS implementation perf. If it doesn't work we'll have to go for the long press on new conversation to show the debug menu, however the shake was useful to get debug logs during onboarding.