### PR TITLE
Add a step to copy over env variables when building through github

### DIFF
--- a/.github/workflows/build-internal.yml
+++ b/.github/workflows/build-internal.yml
@@ -39,6 +39,9 @@ jobs:
           echo "EXPO_PUBLIC_EXPO_PROJECT_ID=${{ secrets.EXPO_PUBLIC_EXPO_PROJECT_ID }}" >> .env.production
           echo "EXPO_PUBLIC_PRIVY_APP_ID=${{ secrets.EXPO_PUBLIC_PRIVY_APP_ID }}" >> .env.production
           echo "EXPO_PUBLIC_EVM_RPC_ENDPOINT=${{ secrets.EXPO_PUBLIC_EVM_RPC_ENDPOINT }}" >> .env.production
+      
+      - name: Update EAS config with env variables
+        run: node scripts/build/eas.js --env production
 
       - name: Update Android Files
         # TODO: This should be handled by build configs in the future
@@ -79,6 +82,9 @@ jobs:
           echo "EXPO_PUBLIC_EXPO_PROJECT_ID=${{ secrets.EXPO_PUBLIC_EXPO_PROJECT_ID }}" >> .env.production
           echo "EXPO_PUBLIC_PRIVY_APP_ID=${{ secrets.EXPO_PUBLIC_PRIVY_APP_ID }}" >> .env.production
           echo "EXPO_PUBLIC_EVM_RPC_ENDPOINT=${{ secrets.EXPO_PUBLIC_EVM_RPC_ENDPOINT }}" >> .env.production
+      
+      - name: Update EAS config with env variables
+        run: node scripts/build/eas.js --env production
 
       - name: Update iOS Files
         # TODO: This should be handled by schemes in the future

--- a/scripts/build/eas.js
+++ b/scripts/build/eas.js
@@ -23,3 +23,11 @@ const handleEnv = (environment) => {
 };
 
 module.exports = { handleEnv };
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args[0] !== "--env") {
+    throw new Error("Only --env argument is supported");
+  }
+  handleEnv(args[1]);
+}


### PR DESCRIPTION
As discussed on Slack, the build action is missing a step to copy env variables to the eas config (as we do when we call locally yarn build), leading to no config being set