### PR TITLE
Prevent crashing if db is already closed

### DIFF
--- a/data/db/driver.ts
+++ b/data/db/driver.ts
@@ -4,6 +4,7 @@ import {
   QueryResult,
   Transaction,
 } from "@op-engineering/op-sqlite";
+import logger from "@utils/logger";
 import { v4 as uuidv4 } from "uuid";
 
 // Inspired from https://github.com/margelo/react-native-quick-sqlite/blob/be9235eef7d892ed46177f4d4031cc1a9af723ad/src/index.ts#L348
@@ -17,7 +18,17 @@ const databasesConnections: {
 
 export const dropConverseDbConnections = () => {
   Object.values(databasesConnections).forEach((db) => {
-    db.connection.close();
+    try {
+      db.connection.close();
+    } catch (e) {
+      if (`${e}`.includes("DB is not open")) {
+        logger.debug(
+          `Could not close ${db.options.name} as it's already closed.`
+        );
+      } else {
+        throw e;
+      }
+    }
   });
 };
 


### PR DESCRIPTION
Fix for [that Sentry error](https://converse-app.sentry.io/issues/5667098779/?environment=prod&project=4504757120729088&query=is:unresolved+issue.priority:%5Bhigh,+medium%5D&statsPeriod=24h&stream_index=0&utc=true) which made my prod app crash.

I'm not 100% sure why we would call close on a closed db. Maybe if we leave and come back to the app fast. Anyways no need to close a closed db so I think this fix can work.