### PR TITLE
Show app version in debug menu

### DIFF
--- a/components/DebugButton.tsx
+++ b/components/DebugButton.tsx
@@ -2,10 +2,11 @@ import Clipboard from "@react-native-clipboard/clipboard";
 import * as Sentry from "@sentry/react-native";
 import { loggingFilePath, rotateLoggingFile } from "@utils/logger";
 import axios from "axios";
+import Constants from "expo-constants";
 import { Image } from "expo-image";
 import * as Updates from "expo-updates";
 import { forwardRef, useImperativeHandle } from "react";
-import { Share } from "react-native";
+import { Platform, Share } from "react-native";
 
 import { showActionSheetWithOptions } from "./StateHandlers/ActionSheetStateHandler";
 import config from "../config";
@@ -25,6 +26,11 @@ export async function delayToPropogate(): Promise<void> {
 }
 
 const DebugButton = forwardRef((props, ref) => {
+  const appVersion = Constants.expoConfig?.version;
+  const buildNumber =
+    Platform.OS === "ios"
+      ? Constants.expoConfig?.ios?.buildNumber
+      : Constants.expoConfig?.android?.versionCode;
   // The component instance will be extended
   // with whatever you return from the callback passed
   // as the second argument
@@ -95,6 +101,7 @@ const DebugButton = forwardRef((props, ref) => {
 
       showActionSheetWithOptions(
         {
+          title: `Converse v${appVersion} (${buildNumber})`,
           options,
           cancelButtonIndex: options.indexOf("Cancel"),
         },


### PR DESCRIPTION
<img width="458" alt="Capture d’écran 2024-08-09 à 12 05 05" src="https://github.com/user-attachments/assets/4962e016-ba9b-4d16-9ab3-a4a1520415f3">

Show the app version inside the debug menu, especially useful during onboarding