### PR TITLE
feat: place reactions outside bubbles for attachments, frames, transactions

### DIFF
--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -583,8 +583,7 @@ const useStyles = () => {
       marginBottom: 8,
     },
     outsideReactionsContainer: {
-      flexShrink: 1,
-      flexGrow: 1,
+      flex: 1,
     },
   });
 };

--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -18,6 +18,7 @@ import {
   TouchableOpacity,
   View,
   useColorScheme,
+  DimensionValue,
 } from "react-native";
 import { Swipeable } from "react-native-gesture-handler";
 
@@ -182,6 +183,24 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
   const reactions = getMessageReactions(message);
   const showInBubble = !isGroupUpdated;
   const showAvatar = isGroup && !message.fromMe;
+  const showReactionsOutside = isAttachment || isFrame || isTransaction;
+
+  let messageMaxWidth: DimensionValue;
+  if (isDesktop) {
+    if (isAttachment) {
+      messageMaxWidth = 366;
+    } else {
+      messageMaxWidth = 588;
+    }
+  } else {
+    if (isAttachment) {
+      messageMaxWidth = "70%";
+    } else {
+      if (isFrame) {
+        messageMaxWidth = "100%";
+      } else messageMaxWidth = "85%";
+    }
+  }
 
   const showStatus =
     message.fromMe &&
@@ -289,6 +308,7 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
                 style={{
                   alignSelf: message.fromMe ? "flex-end" : "flex-start",
                   alignItems: message.fromMe ? "flex-end" : "flex-start",
+                  maxWidth: messageMaxWidth,
                 }}
               >
                 <ChatMessageActions
@@ -341,18 +361,6 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
                       >
                         {messageContent}
                       </View>
-                      <View
-                        style={
-                          isAttachment || isFrame || isTransaction
-                            ? { position: "absolute", bottom: 0, zIndex: 1 }
-                            : undefined
-                        }
-                      >
-                        <ChatMessageReactions
-                          message={message}
-                          reactions={reactions}
-                        />
-                      </View>
                     </View>
                   ) : (
                     <View
@@ -363,39 +371,34 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
                           : undefined,
                       ]}
                     >
-                      <View style={{ zIndex: 0 }}>{messageContent}</View>
-                      <View
-                        style={
-                          isAttachment || isFrame || isTransaction
-                            ? { position: "absolute", bottom: 0, zIndex: 1 }
-                            : undefined
-                        }
-                      >
+                      <View>{messageContent}</View>
+                    </View>
+                  )}
+                  {Object.keys(reactions).length > 0 &&
+                    !showReactionsOutside && (
+                      <View style={{ marginHorizontal: 8, marginBottom: 8 }}>
                         <ChatMessageReactions
                           message={message}
                           reactions={reactions}
                         />
                       </View>
-                    </View>
-                  )}
+                    )}
                 </ChatMessageActions>
-                <View
-                  style={{
-                    flexDirection: "row",
-                    flexBasis: "100%",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                  }}
-                >
+                <View style={{ marginTop: showReactionsOutside ? 4 : 0 }}>
                   {isFrame && (
                     <TouchableOpacity
                       onPress={() => handleUrlPress(message.content)}
-                      style={{ flex: 1 }}
                     >
                       <Text style={styles.linkToFrame}>
                         {getUrlToRender(message.content)}
                       </Text>
                     </TouchableOpacity>
+                  )}
+                  {showReactionsOutside && (
+                    <ChatMessageReactions
+                      message={message}
+                      reactions={reactions}
+                    />
                   )}
                   {message.fromMe && (
                     <View style={styles.statusContainer}>
@@ -534,8 +537,8 @@ const useStyles = () => {
       paddingHorizontal: 0,
     },
     messageContentContainer: {
-      paddingVertical: 8,
-      paddingHorizontal: 14,
+      paddingVertical: 6,
+      paddingHorizontal: 10,
     },
     messageText: {
       color: textPrimaryColor(colorScheme),

--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -220,8 +220,8 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
   const messageAttachment = useChatStore(
     (state) => state.messageAttachments[message.id] || null
   );
-  const attachmentStillLoading =
-    isAttachment && (!messageAttachment || messageAttachment.loading);
+
+  const hasReactions = Object.keys(reactions).length > 0;
 
   const swipeableRef = useRef<Swipeable | null>(null);
 
@@ -374,17 +374,18 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
                       <View>{messageContent}</View>
                     </View>
                   )}
-                  {Object.keys(reactions).length > 0 &&
-                    !showReactionsOutside && (
-                      <View style={{ marginHorizontal: 8, marginBottom: 8 }}>
-                        <ChatMessageReactions
-                          message={message}
-                          reactions={reactions}
-                        />
-                      </View>
-                    )}
+                  {hasReactions && !showReactionsOutside && (
+                    <View style={styles.reactionsContainer}>
+                      <ChatMessageReactions
+                        message={message}
+                        reactions={reactions}
+                      />
+                    </View>
+                  )}
                 </ChatMessageActions>
-                <View style={{ marginTop: showReactionsOutside ? 4 : 0 }}>
+                <View
+                  style={showReactionsOutside && styles.outsideMetaContainer}
+                >
                   {isFrame && (
                     <TouchableOpacity
                       onPress={() => handleUrlPress(message.content)}
@@ -395,15 +396,15 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
                     </TouchableOpacity>
                   )}
                   {showReactionsOutside && (
-                    <ChatMessageReactions
-                      message={message}
-                      reactions={reactions}
-                    />
-                  )}
-                  {message.fromMe && (
-                    <View style={styles.statusContainer}>
-                      <MessageStatus message={message} />
+                    <View style={styles.outsideReactionsContainer}>
+                      <ChatMessageReactions
+                        message={message}
+                        reactions={reactions}
+                      />
                     </View>
+                  )}
+                  {message.fromMe && !hasReactions && (
+                    <MessageStatus message={message} />
                   )}
                 </View>
               </View>
@@ -510,15 +511,11 @@ const useStyles = () => {
       flexDirection: "row",
       flexWrap: "wrap",
     },
-    statusContainer: {
-      marginLeft: "auto",
-    },
     linkToFrame: {
       fontSize: 12,
-      marginVertical: 7,
-      marginLeft: 6,
-      marginRight: "auto",
+      padding: 6,
       color: textSecondaryColor(colorScheme),
+      flexGrow: 1,
     },
     date: {
       flexBasis: "100%",
@@ -573,6 +570,21 @@ const useStyles = () => {
     avatarPlaceholder: {
       width: AvatarSizes.messageSender,
       height: AvatarSizes.messageSender,
+    },
+    outsideMetaContainer: {
+      marginTop: 4,
+      flexDirection: "row",
+      justifyContent: "flex-start",
+      columnGap: 8,
+      width: "100%",
+    },
+    reactionsContainer: {
+      marginHorizontal: 8,
+      marginBottom: 8,
+    },
+    outsideReactionsContainer: {
+      flexShrink: 1,
+      flexGrow: 1,
     },
   });
 };

--- a/components/Chat/Message/MessageActions.tsx
+++ b/components/Chat/Message/MessageActions.tsx
@@ -10,7 +10,6 @@ import * as Haptics from "expo-haptics";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ColorSchemeName,
-  DimensionValue,
   Platform,
   StyleSheet,
   useColorScheme,
@@ -40,7 +39,6 @@ import { useFramesStore } from "../../../data/store/framesStore";
 import { ReanimatedTouchableOpacity } from "../../../utils/animations";
 import { isAttachmentMessage } from "../../../utils/attachment/helpers";
 import { useConversationContext } from "../../../utils/conversation";
-import { isDesktop } from "../../../utils/device";
 import { converseEventEmitter } from "../../../utils/events";
 import {
   MessageReaction,
@@ -77,23 +75,6 @@ export default function ChatMessageActions({
   const frames = useFramesStore().frames;
   const isFrame = !!frames[message.content.toLowerCase()];
   const styles = useStyles();
-
-  let messageMaxWidth: DimensionValue;
-  if (isDesktop) {
-    if (isAttachment) {
-      messageMaxWidth = 366;
-    } else {
-      messageMaxWidth = 588;
-    }
-  } else {
-    if (isAttachment) {
-      messageMaxWidth = "70%";
-    } else {
-      if (isFrame) {
-        messageMaxWidth = "100%";
-      } else messageMaxWidth = "85%";
-    }
-  }
 
   const [emojiPickerShown, setEmojiPickerShown] = useState(false);
 
@@ -391,7 +372,7 @@ export default function ChatMessageActions({
                   },
                 }),
                 {
-                  maxWidth: messageMaxWidth,
+                  // maxWidth: messageMaxWidth,
                 },
               ]}
               onPress={() => {
@@ -499,10 +480,9 @@ const useStyles = () => {
     messageBubble: {
       flexShrink: 1,
       flexGrow: 0,
-      minHeight: 36,
-      borderRadius: 18,
+      minHeight: 32,
+      borderRadius: 16,
     },
-
     messageBubbleMe: {
       marginLeft: "auto",
     },

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -32,6 +32,7 @@ import {
 import { showActionSheetWithOptions } from "../../StateHandlers/ActionSheetStateHandler";
 
 const MAX_REACTORS_TO_SHOW = 3;
+const REACTOR_OFFSET = 10;
 
 type Props = {
   message: MessageToDisplay;
@@ -160,9 +161,6 @@ export default function ChatMessageReactions({ message, reactions }: Props) {
     <View style={styles.reactionsWrapper}>
       {reactionCounts.map((reaction) => {
         const reactorCount = reaction.reactors.length;
-        const containerWidth =
-          reactorCount > MAX_REACTORS_TO_SHOW ? 20 : reactorCount * 15 + 5;
-
         return (
           <TouchableOpacity
             key={reaction.content}
@@ -176,25 +174,36 @@ export default function ChatMessageReactions({ message, reactions }: Props) {
             ]}
           >
             <Text style={styles.emoji}>{reaction.content}</Text>
-            <View style={[styles.reactorContainer, { width: containerWidth }]}>
-              {reaction.reactors &&
-              reaction.reactors.length <= MAX_REACTORS_TO_SHOW ? (
-                reaction.reactors.slice(0, 3).map((reactor, index) => (
-                  <Image
-                    key={reactor}
-                    source={{
-                      uri: getPreferredAvatar(profiles[reactor]?.socials),
-                    }}
-                    style={[
-                      styles.profileImage,
-                      reaction.userReacted
-                        ? { borderColor: primaryColor(colorScheme) }
-                        : {},
-                      { right: index * 13 },
-                    ]}
-                  />
-                ))
-              ) : (
+            {reactorCount <= MAX_REACTORS_TO_SHOW ? (
+              <View
+                style={[
+                  styles.reactorContainer,
+                  { marginRight: (reactorCount - 1) * -REACTOR_OFFSET },
+                ]}
+              >
+                {reaction.reactors
+                  .slice(0, MAX_REACTORS_TO_SHOW)
+                  .map((reactor, index) => (
+                    <Image
+                      key={reactor}
+                      source={{
+                        uri: getPreferredAvatar(profiles[reactor]?.socials),
+                      }}
+                      style={[
+                        styles.profileImage,
+                        {
+                          left: index * -REACTOR_OFFSET,
+                          zIndex: MAX_REACTORS_TO_SHOW - (index + 1),
+                        },
+                        reaction.userReacted
+                          ? { borderColor: primaryColor(colorScheme) }
+                          : {},
+                      ]}
+                    />
+                  ))}
+              </View>
+            ) : (
+              <View style={styles.reactorContainer}>
                 <Text
                   style={[
                     styles.reactorCount,
@@ -203,10 +212,10 @@ export default function ChatMessageReactions({ message, reactions }: Props) {
                       : {},
                   ]}
                 >
-                  +{reaction.reactors.length}
+                  {reactorCount}
                 </Text>
-              )}
-            </View>
+              </View>
+            )}
           </TouchableOpacity>
         );
       })}
@@ -233,32 +242,29 @@ const useStyles = () => {
     },
     myReactionButton: {
       backgroundColor: primaryColor(colorScheme),
-      borderWidth: 0.5,
-      borderColor: inversePrimaryColor(colorScheme),
     },
     otherReactionButton: {
       backgroundColor: backgroundColor(colorScheme),
     },
     emoji: {
-      fontSize: 18,
-      marginRight: 2,
+      fontSize: 14,
+      marginHorizontal: 2,
     },
     reactorContainer: {
       flexDirection: "row",
       alignItems: "center",
-      height: 20,
-      position: "relative",
+      height: 22,
     },
     profileImage: {
-      width: 20,
-      height: 20,
-      borderRadius: 10,
-      position: "absolute",
-      borderWidth: 0.5,
+      width: 22,
+      height: 22,
+      borderRadius: 22,
+      borderWidth: 1,
       borderColor: inversePrimaryColor(colorScheme),
     },
     reactorCount: {
       fontSize: 12,
+      marginHorizontal: 2,
       color: textPrimaryColor(colorScheme),
     },
   });

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -2,7 +2,7 @@ import {
   actionSheetColors,
   inversePrimaryColor,
   textPrimaryColor,
-  backgroundColor,
+  tertiaryBackgroundColor,
   primaryColor,
 } from "@styles/colors";
 import { useCallback, useMemo } from "react";
@@ -20,7 +20,6 @@ import {
   useCurrentAccount,
   useProfilesStore,
 } from "../../../data/store/accountsStore";
-import { isAttachmentMessage } from "../../../utils/attachment/helpers";
 import { useConversationContext } from "../../../utils/conversation";
 import { getPreferredName, getPreferredAvatar } from "../../../utils/profile";
 import {
@@ -128,14 +127,12 @@ export default function ChatMessageReactions({ message, reactions }: Props) {
       };
     });
     methods["Back"] = () => {};
-    const isAttachment = isAttachmentMessage(message.contentType);
 
     const options = Object.keys(methods);
 
     showActionSheetWithOptions(
       {
         options,
-        title: isAttachment ? "📎 Media" : message.content,
         cancelButtonIndex: options.indexOf("Back"),
         ...actionSheetColors(colorScheme),
       },
@@ -158,7 +155,12 @@ export default function ChatMessageReactions({ message, reactions }: Props) {
   if (reactionsList.length === 0) return null;
 
   return (
-    <View style={styles.reactionsWrapper}>
+    <View
+      style={[
+        styles.reactionsWrapper,
+        message.fromMe && { justifyContent: "flex-end" },
+      ]}
+    >
       {reactionCounts.map((reaction) => {
         const reactorCount = reaction.reactors.length;
         return (
@@ -169,7 +171,9 @@ export default function ChatMessageReactions({ message, reactions }: Props) {
             style={[
               styles.reactionButton,
               reaction.userReacted
-                ? styles.myReactionButton
+                ? message.fromMe
+                  ? styles.myReactionToMyMessageButton
+                  : styles.myReactionToOtherMessageButton
                 : styles.otherReactionButton,
             ]}
           >
@@ -196,8 +200,10 @@ export default function ChatMessageReactions({ message, reactions }: Props) {
                           zIndex: MAX_REACTORS_TO_SHOW - (index + 1),
                         },
                         reaction.userReacted
-                          ? { borderColor: primaryColor(colorScheme) }
-                          : {},
+                          ? message.fromMe
+                            ? styles.myReactionToMyMessageProfileImage
+                            : styles.myReactionToOtherMessageProfileImage
+                          : styles.otherProfileImage,
                       ]}
                     />
                   ))}
@@ -229,22 +235,43 @@ const useStyles = () => {
     reactionsWrapper: {
       flexDirection: "row",
       flexWrap: "wrap",
-      marginHorizontal: 10,
+      rowGap: 4,
+      columnGap: 5,
     },
     reactionButton: {
       flexDirection: "row",
       alignItems: "center",
-      marginRight: 8,
-      marginBottom: 8,
-      paddingHorizontal: 8,
-      paddingVertical: 4,
+      paddingHorizontal: 4,
+      paddingVertical: 2,
       borderRadius: 16,
+      borderWidth: 0.25,
     },
-    myReactionButton: {
-      backgroundColor: primaryColor(colorScheme),
+    profileImage: {
+      width: 22,
+      height: 22,
+      borderRadius: 22,
+      borderWidth: 1,
     },
     otherReactionButton: {
-      backgroundColor: backgroundColor(colorScheme),
+      backgroundColor: tertiaryBackgroundColor(colorScheme),
+      borderColor: tertiaryBackgroundColor(colorScheme),
+    },
+    otherProfileImage: {
+      borderColor: tertiaryBackgroundColor(colorScheme),
+    },
+    myReactionToOtherMessageButton: {
+      backgroundColor: primaryColor(colorScheme),
+      borderColor: primaryColor(colorScheme),
+    },
+    myReactionToOtherMessageProfileImage: {
+      borderColor: primaryColor(colorScheme),
+    },
+    myReactionToMyMessageButton: {
+      backgroundColor: primaryColor(colorScheme),
+      borderColor: tertiaryBackgroundColor(colorScheme),
+    },
+    myReactionToMyMessageProfileImage: {
+      borderColor: primaryColor(colorScheme),
     },
     emoji: {
       fontSize: 14,
@@ -254,13 +281,6 @@ const useStyles = () => {
       flexDirection: "row",
       alignItems: "center",
       height: 22,
-    },
-    profileImage: {
-      width: 22,
-      height: 22,
-      borderRadius: 22,
-      borderWidth: 1,
-      borderColor: inversePrimaryColor(colorScheme),
     },
     reactorCount: {
       fontSize: 12,

--- a/components/Chat/Message/MessageStatus.tsx
+++ b/components/Chat/Message/MessageStatus.tsx
@@ -1,5 +1,5 @@
 import { textSecondaryColor } from "@styles/colors";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { StyleSheet, useColorScheme, View } from "react-native";
 import Animated, {
   useSharedValue,
@@ -32,12 +32,13 @@ export default function MessageStatus({ message }: Props) {
     message.status === "sent" || message.status === "delivered";
   const isLatestSettledFromMe = message.isLatestSettledFromMe;
 
+  const [renderText, setRenderText] = useState(false);
   const opacity = useSharedValue(message.isLatestSettledFromMe ? 1 : 0);
   const height = useSharedValue(message.isLatestSettledFromMe ? 22 : 0);
   const scale = useSharedValue(message.isLatestSettledFromMe ? 1 : 0);
 
   const timingConfig = {
-    duration: 100,
+    duration: 200,
     easing: Easing.inOut(Easing.quad),
   };
 
@@ -61,17 +62,20 @@ export default function MessageStatus({ message }: Props) {
             opacity.value = withTiming(1, timingConfig);
             height.value = withTiming(22, timingConfig);
             scale.value = withTiming(1, timingConfig);
+            setRenderText(true);
           } else if (isSentOrDelivered && !isLatestSettledFromMe) {
             opacity.value = withTiming(0, timingConfig);
             height.value = withTiming(0, timingConfig);
             scale.value = withTiming(0, timingConfig);
+            setTimeout(() => setRenderText(false), timingConfig.duration);
           } else if (isLatestSettledFromMe) {
             opacity.value = 1;
             height.value = 22;
             scale.value = 1;
+            setRenderText(true);
           }
         });
-      }, 200);
+      }, 100);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [isLatestSettledFromMe, isSentOrDelivered]
@@ -84,7 +88,7 @@ export default function MessageStatus({ message }: Props) {
       <Animated.View style={[styles.container, animatedStyle]}>
         <View style={styles.contentContainer}>
           <Animated.Text style={styles.statusText}>
-            {statusMapping[message.status]}
+            {renderText && statusMapping[message.status]}
           </Animated.Text>
         </View>
       </Animated.View>
@@ -104,7 +108,6 @@ const useStyles = () => {
     statusText: {
       fontSize: 12,
       color: textSecondaryColor(colorScheme),
-      marginRight: 3,
     },
   });
 };


### PR DESCRIPTION
- Places reactions outside of bubbles for attachment, frame, and transaction messages
- Removes inconsistent borders, absolute positioning from all messages
<img src="https://github.com/user-attachments/assets/b3e50563-80ca-4ec6-8d18-70ecbdde18d7" width = 350 />


