### PR TITLE
Noe/initial load performance

### DIFF
--- a/utils/xmtpRN/sync.ts
+++ b/utils/xmtpRN/sync.ts
@@ -69,7 +69,9 @@ export const getXmtpClient = async (
       delete instantiatingClientForAccount[account];
     }
   })();
-  return instantiatingClientForAccount[account];
+  return instantiatingClientForAccount[account] as Promise<
+    ConverseXmtpClientType | Client
+  >;
 };
 
 const INITIAL_BACKOFF = 1000; // Initial backoff interval in ms


### PR DESCRIPTION
Better handling of instantiating clients

- return the same promise for everyone that's awaiting getClient
- prevent creation of 2 clients (for different accounts) in //

This might help with weird "already instantiating" loops and maybe Client instantiation locks on the Swift side