### PR TITLE
Fix: allow to restore blocked users from the Removed Chat view

### DIFF
--- a/components/ConversationList/GroupConversationItem.tsx
+++ b/components/ConversationList/GroupConversationItem.tsx
@@ -74,7 +74,8 @@ export const GroupConversationItem: FC<GroupConversationItemProps> = ({
           {
             options,
             cancelButtonIndex: options.length - 1,
-            destructiveButtonIndex: [0, 1],
+            // Only show red buttons for destructive actions
+            destructiveButtonIndex: consent === "denied" ? undefined : [0, 1],
             title,
             ...actionSheetColors(colorScheme),
           },

--- a/components/ConversationList/GroupConversationItem.tsx
+++ b/components/ConversationList/GroupConversationItem.tsx
@@ -89,53 +89,49 @@ export const GroupConversationItem: FC<GroupConversationItemProps> = ({
         );
       };
 
-      switch (consent) {
-        case "denied":
-          showOptions(
-            [
-              translate("restore"),
-              translate("restore_and_unblock_inviter"),
-              translate("cancel"),
-            ],
-            `${translate("restore")} ${groupName}?`,
-            [
-              () =>
-                allowGroup({
-                  includeAddedBy: false,
-                  includeCreator: false,
-                }),
-              () =>
-                allowGroup({
-                  includeAddedBy: true,
-                  includeCreator: false,
-                }),
-            ]
-          );
-          break;
-
-        // for allowed and unknown
-        default:
-          showOptions(
-            [
-              translate("remove"),
-              translate("remove_and_block_inviter"),
-              translate("cancel"),
-            ],
-            `${translate("remove")} ${groupName}?`,
-            [
-              () =>
-                blockGroup({
-                  includeAddedBy: false,
-                  includeCreator: false,
-                }),
-              () =>
-                blockGroup({
-                  includeAddedBy: true,
-                  includeCreator: false,
-                }),
-            ]
-          );
-          break;
+      if (consent === "denied") {
+        showOptions(
+          [
+            translate("restore"),
+            translate("restore_and_unblock_inviter"),
+            translate("cancel"),
+          ],
+          `${translate("restore")} ${groupName}?`,
+          [
+            () =>
+              allowGroup({
+                includeAddedBy: false,
+                includeCreator: false,
+              }),
+            () =>
+              allowGroup({
+                includeAddedBy: true,
+                includeCreator: false,
+              }),
+          ]
+        );
+      } else {
+        // for allowed and unknown consent
+        showOptions(
+          [
+            translate("remove"),
+            translate("remove_and_block_inviter"),
+            translate("cancel"),
+          ],
+          `${translate("remove")} ${groupName}?`,
+          [
+            () =>
+              blockGroup({
+                includeAddedBy: false,
+                includeCreator: false,
+              }),
+            () =>
+              blockGroup({
+                includeAddedBy: true,
+                includeCreator: false,
+              }),
+          ]
+        );
       }
     },
     [allowGroup, blockGroup, consent, colorScheme, groupName]

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -10,11 +10,13 @@ const en = {
 
   // Conversation List
   delete: "Delete",
+  delete_chat_with: "Delete chat with",
   delete_and_block: "Delete and block",
   remove: "Remove",
   remove_and_block_inviter: "Remove and block inviter",
   restore: "Restore",
   restore_and_unblock_inviter: "Restore and unblock inviter",
+  unblock_and_restore: "Unblock and restore",
   cancel: "Cancel",
 
   // Conversation


### PR DESCRIPTION
After reviewing and testing yesterday's build v1.4.9 (246), I noticed that blocked (but not deleted) 1:1 conversations were showing up in the Removed Chats list.

I've now updated to allow unblocking directly from the Removed Chats view. The deleted conversations won't appear there, but at least you can now unblock the previously blocked peers from that list.

Please take a look at the [screenshot](https://github.com/user-attachments/assets/6950bfa9-a3a5-4bd0-82c6-66cecb297673) to see

Also fixed the UI only to show red buttons for destructive actions