### PR TITLE
Tentative fix for db corruption

### DIFF
--- a/components/XmtpEngine.tsx
+++ b/components/XmtpEngine.tsx
@@ -75,18 +75,19 @@ export default function XmtpEngine() {
       async (nextAppState) => {
         if (
           nextAppState === "active" &&
-          appState.current.match(/inactive|background/) &&
-          hydrationDone
+          appState.current.match(/inactive|background/)
         ) {
           reconnectConverseDbConnections();
-          loadSavedNotificationMessagesToContext();
-          // Refreshing profiles store from mmkv
-          // as we could have added data from notification
-          accounts.forEach((a) => {
-            getProfilesStore(a).getState().refreshFromStorage();
-          });
-          if (isInternetReachableRef.current) {
-            syncAccounts(accounts);
+          if (hydrationDone) {
+            loadSavedNotificationMessagesToContext();
+            // Refreshing profiles store from mmkv
+            // as we could have added data from notification
+            accounts.forEach((a) => {
+              getProfilesStore(a).getState().refreshFromStorage();
+            });
+            if (isInternetReachableRef.current) {
+              syncAccounts(accounts);
+            }
           }
         } else if (
           nextAppState.match(/inactive|background/) &&

--- a/data/db/driver.ts
+++ b/data/db/driver.ts
@@ -56,6 +56,7 @@ export const reconnectConverseDbConnections = () => {
       name: options.name,
       location: options.location,
     });
+    logger.debug(`Reopened db ${options.name}`);
     databasesConnections[dbId].connection = newDb;
   });
 };

--- a/data/db/index.ts
+++ b/data/db/index.ts
@@ -71,7 +71,7 @@ export const initDb = async (account: string): Promise<void> => {
   try {
     await dataSource.initialize();
     logger.debug(`Database initialized for ${account}`);
-    await waitUntilAppActive(500, 1500);
+    await waitUntilAppActive(1500);
     // https://phiresky.github.io/blog/2020/sqlite-performance-tuning/
     await Promise.all([
       dataSource.query(
@@ -84,7 +84,7 @@ export const initDb = async (account: string): Promise<void> => {
     logger.debug(`Database optimized for ${account}`);
     try {
       logger.debug(`Running migrations for ${account}`);
-      await waitUntilAppActive(500, 1500);
+      await waitUntilAppActive(1500);
       await dataSource.runMigrations();
       logger.debug(`Migrations done for ${account}`);
       repositories[account] = {
@@ -140,7 +140,7 @@ export const clearConverseDb = async (account: string, dbPath: string) => {
   try {
     const dataSource = getExistingDataSource(account);
     if (dataSource) {
-      await waitUntilAppActive(500, 1500);
+      await waitUntilAppActive(1500);
       await dataSource.destroy();
       logger.debug(`[ClearDB] Datasource destroyed - ${account}`);
     } else {

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "expo-updates": "~0.25.22",
     "expo-web-browser": "~13.0.3",
     "fast-deep-equal": "^3.1.3",
+    "fast_array_intersect": "^1.1.0",
     "flatted": "^3.3.1",
     "https-browserify": "^1.0.0",
     "i18n-js": "3.9.2",

--- a/utils/appState.ts
+++ b/utils/appState.ts
@@ -1,0 +1,28 @@
+import { AppState } from "react-native";
+
+import logger from "./logger";
+
+/*
+Method to wait until the app is in Foreground (Active)
+helpful to make sure we're not doing critical database stuff
+while the database is disconnected to prevent data loss
+Will check every delayMs, then wait endDelayMs for db reconnection
+*/
+export const waitUntilAppActive = async (
+  delayMs: number,
+  endDelayMs: number
+) => {
+  let appWasInactive = false;
+  while (AppState.currentState !== "active") {
+    appWasInactive = true;
+    logger.debug(`App is inactive, waiting ${delayMs}ms until back active`);
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  if (appWasInactive) {
+    logger.debug(`App was inactive for a while, waiting ${endDelayMs}ms more`);
+    await new Promise((r) => setTimeout(r, endDelayMs));
+    if (AppState.currentState !== "active") {
+      await waitUntilAppActive(delayMs, endDelayMs);
+    }
+  }
+};

--- a/utils/appState.ts
+++ b/utils/appState.ts
@@ -8,21 +8,28 @@ helpful to make sure we're not doing critical database stuff
 while the database is disconnected to prevent data loss
 Will check every delayMs, then wait endDelayMs for db reconnection
 */
-export const waitUntilAppActive = async (
-  delayMs: number,
-  endDelayMs: number
-) => {
-  let appWasInactive = false;
-  while (AppState.currentState !== "active") {
-    appWasInactive = true;
-    logger.debug(`App is inactive, waiting ${delayMs}ms until back active`);
-    await new Promise((r) => setTimeout(r, delayMs));
-  }
-  if (appWasInactive) {
-    logger.debug(`App was inactive for a while, waiting ${endDelayMs}ms more`);
-    await new Promise((r) => setTimeout(r, endDelayMs));
-    if (AppState.currentState !== "active") {
-      await waitUntilAppActive(delayMs, endDelayMs);
-    }
-  }
+export const waitUntilAppActive = async (endDelayMs: number) => {
+  // If app is active, return immediatly
+  if (AppState.currentState === "active") return;
+  logger.debug(`Waiting until app is back into active state...`);
+  return new Promise((resolve) => {
+    const subscription = AppState.addEventListener(
+      "change",
+      async (nextAppState) => {
+        if (nextAppState === "active") {
+          subscription.remove();
+          logger.debug(
+            `App was inactive for a while, waiting ${endDelayMs}ms more`
+          );
+          await new Promise((r) => setTimeout(r, endDelayMs));
+          // Check if app is still active after endDelayMs
+          if (AppState.currentState !== "active") {
+            await waitUntilAppActive(endDelayMs);
+          } else {
+            resolve(undefined);
+          }
+        }
+      }
+    );
+  });
 };

--- a/utils/xmtpRN/sync.ts
+++ b/utils/xmtpRN/sync.ts
@@ -1,5 +1,6 @@
 import logger from "@utils/logger";
 import { Client } from "@xmtp/xmtp-js";
+import intersect from "fast_array_intersect";
 import { AppState } from "react-native";
 
 import { xmtpSignatureByAccount } from "./api";
@@ -121,11 +122,15 @@ const streamingAccounts: { [account: string]: boolean } = {};
 export const syncXmtpClient = async (account: string) => {
   const lastSyncedAt = getChatStore(account).getState().lastSyncedAt || 0;
 
-  // We just introduced lastSyncedTopics so it might be empty at first
   // Last synced topics enable us not to miss messages from new conversations
   // That we didn't get through notifications
-  const lastSyncedTopics =
+  const _lastSyncedTopics =
     getChatStore(account).getState().lastSyncedTopics || [];
+  // Making sure we know about those convos in case of database issue
+  const lastSyncedTopics = intersect([
+    _lastSyncedTopics,
+    Object.keys(getChatStore(account).getState().conversations),
+  ]);
   const knownTopics =
     lastSyncedTopics.length > 0
       ? lastSyncedTopics

--- a/yarn.lock
+++ b/yarn.lock
@@ -14284,6 +14284,11 @@ fast-xml-parser@^4.2.5:
   dependencies:
     strnum "^1.0.5"
 
+fast_array_intersect@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast_array_intersect/-/fast_array_intersect-1.1.0.tgz#8e8a83d95c515fd55bfb2b02da94da3d7f1c2b8b"
+  integrity sha512-/DCilZlUdz2XyNDF+ASs0PwY+RKG9Y4Silp/gbS72Cvbg4oibc778xcecg+pnNyiNHYgh/TApsiDTjpdniyShw==
+
 fastq@^1.6.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"


### PR DESCRIPTION
We saw cases where only group convos were showing
I suspect this is some db corruption introduced with the recent db disconnect feature because we save all group convos to db but only the 1:1 that are "new" so it would end up having only groups if there is a corruption

Tentative fix
- make sure we reconnect database even if hydration not done
- wait until app is back active before doing some critical database actions
- recover from a corruption by repulling all from network