### PR TITLE
chore: Clean up translations

### DIFF
--- a/components/AccountSettingsButton.tsx
+++ b/components/AccountSettingsButton.tsx
@@ -1,4 +1,4 @@
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import Clipboard from "@react-native-clipboard/clipboard";
 import { NavigationProp } from "@react-navigation/native";
 import {

--- a/components/Chat/Attachment/AddAttachmentButton.tsx
+++ b/components/Chat/Attachment/AddAttachmentButton.tsx
@@ -1,4 +1,4 @@
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import { MenuView } from "@react-native-menu/menu";
 import { textPrimaryColor } from "@styles/colors";
 import { RemoteAttachmentContent } from "@xmtp/react-native-sdk";

--- a/components/Chat/Attachment/AttachmentMessagePreview.tsx
+++ b/components/Chat/Attachment/AttachmentMessagePreview.tsx
@@ -1,4 +1,4 @@
-import { translate } from "@i18n/translate";
+import { translate } from "@i18n";
 import {
   backgroundColor,
   textPrimaryColor,

--- a/components/Chat/ChatPlaceholder/GroupChatPlaceholder.tsx
+++ b/components/Chat/ChatPlaceholder/GroupChatPlaceholder.tsx
@@ -1,7 +1,7 @@
 import { useGroupConsent } from "@hooks/useGroupConsent";
 import { useGroupMembers } from "@hooks/useGroupMembers";
 import { useGroupName } from "@hooks/useGroupName";
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import { useGroupQuery } from "@queries/useGroupQuery";
 import { actionSheetColors, textPrimaryColor } from "@styles/colors";
 import { useCallback, useMemo } from "react";

--- a/components/Chat/ConsentPopup/ConsentPopup.tsx
+++ b/components/Chat/ConsentPopup/ConsentPopup.tsx
@@ -1,4 +1,4 @@
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import {

--- a/components/Chat/ConsentPopup/GroupConsentPopup.tsx
+++ b/components/Chat/ConsentPopup/GroupConsentPopup.tsx
@@ -2,7 +2,7 @@ import { useSelect } from "@data/store/storeHelpers";
 import { useGroupConsent } from "@hooks/useGroupConsent";
 import { useGroupCreator } from "@hooks/useGroupCreator";
 import { useGroupMembers } from "@hooks/useGroupMembers";
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import {

--- a/components/ConversationList/GroupConversationItem.tsx
+++ b/components/ConversationList/GroupConversationItem.tsx
@@ -1,6 +1,6 @@
 import { showActionSheetWithOptions } from "@components/StateHandlers/ActionSheetStateHandler";
 import { useGroupConsent } from "@hooks/useGroupConsent";
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import { useGroupNameQuery } from "@queries/useGroupNameQuery";
 import { useGroupPhotoQuery } from "@queries/useGroupPhotoQuery";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
@@ -44,7 +44,7 @@ export const GroupConversationItem: FC<GroupConversationItemProps> = ({
     staleTime: Infinity,
     gcTime: Infinity,
   });
-  const { consent, blockGroup, allowGroup } =  useGroupConsent(topic, {
+  const { consent, blockGroup, allowGroup } = useGroupConsent(topic, {
     refetchOnMount: false,
     staleTime: Infinity,
     gcTime: Infinity,

--- a/components/ConversationListItem.tsx
+++ b/components/ConversationListItem.tsx
@@ -1,4 +1,4 @@
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import {
   actionSheetColors,

--- a/components/Onboarding/ConnectViaWallet.tsx
+++ b/components/Onboarding/ConnectViaWallet.tsx
@@ -1,4 +1,4 @@
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { textPrimaryColor, textSecondaryColor } from "@styles/colors";
 import { getDatabaseFilesForInboxId } from "@utils/fileSystem";

--- a/containers/GroupPendingRequestsTable.tsx
+++ b/containers/GroupPendingRequestsTable.tsx
@@ -2,7 +2,7 @@ import { showActionSheetWithOptions } from "@components/StateHandlers/ActionShee
 import { TableViewPicto } from "@components/TableView/TableViewImage";
 import { useCurrentAccount, useProfilesStore } from "@data/store/accountsStore";
 import { useGroupPendingRequests } from "@hooks/useGroupPendingRequests";
-import { translate } from "@i18n/translate";
+import { translate } from "@i18n";
 import { useAddToGroupMutation } from "@queries/useAddToGroupMutation";
 import { invalidatePendingJoinRequestsQuery } from "@queries/usePendingRequestsQuery";
 import { actionSheetColors, textSecondaryColor } from "@styles/colors";

--- a/containers/GroupScreenAddition.tsx
+++ b/containers/GroupScreenAddition.tsx
@@ -7,7 +7,7 @@ import { useGroupMembers } from "@hooks/useGroupMembers";
 import { useGroupName } from "@hooks/useGroupName";
 import { useGroupPermissions } from "@hooks/useGroupPermissions";
 import { useGroupPhoto } from "@hooks/useGroupPhoto";
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import Clipboard from "@react-native-clipboard/clipboard";
 import {
   actionSecondaryColor,

--- a/containers/GroupScreenConsentTable.tsx
+++ b/containers/GroupScreenConsentTable.tsx
@@ -1,5 +1,5 @@
 import { useGroupConsent } from "@hooks/useGroupConsent";
-import { translate } from "@i18n/translate";
+import { translate } from "@i18n";
 import { dangerColor, primaryColor } from "@styles/colors";
 import { FC, useMemo } from "react";
 import { useColorScheme } from "react-native";

--- a/containers/GroupScreenDescription.tsx
+++ b/containers/GroupScreenDescription.tsx
@@ -2,7 +2,7 @@ import { useCurrentAccount } from "@data/store/accountsStore";
 import { useGroupDescription } from "@hooks/useGroupDescription";
 import { useGroupMembers } from "@hooks/useGroupMembers";
 import { useGroupPermissions } from "@hooks/useGroupPermissions";
-import { translate } from "@i18n/translate";
+import { translate } from "@i18n";
 import { textPrimaryColor } from "@styles/colors";
 import {
   getAddressIsAdmin,

--- a/containers/GroupScreenImage.tsx
+++ b/containers/GroupScreenImage.tsx
@@ -5,7 +5,7 @@ import { useGroupMembers } from "@hooks/useGroupMembers";
 import { useGroupPermissions } from "@hooks/useGroupPermissions";
 import { useGroupPhoto } from "@hooks/useGroupPhoto";
 import { usePhotoSelect } from "@hooks/usePhotoSelect";
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import {
   getAddressIsAdmin,
   getAddressIsSuperAdmin,

--- a/containers/GroupScreenMembersTable.tsx
+++ b/containers/GroupScreenMembersTable.tsx
@@ -2,7 +2,7 @@ import { showActionSheetWithOptions } from "@components/StateHandlers/ActionShee
 import { TableViewPicto } from "@components/TableView/TableViewImage";
 import { useCurrentAccount, useProfilesStore } from "@data/store/accountsStore";
 import { useGroupMembers } from "@hooks/useGroupMembers";
-import { translate } from "@i18n/translate";
+import { translate } from "@i18n";
 import { actionSheetColors, textSecondaryColor } from "@styles/colors";
 import {
   getAccountIsAdmin,

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -46,6 +46,17 @@ const en = {
   promote_to_admin: "Promote to admin",
   send_a_message: "Send a message",
   client_error: "Looks like something went wrong, please try reconnecting.",
+  actions: "ACTIONS",
+  common_activity: "COMMON ACTIVITY",
+  social: "SOCIAL",
+  address: "ADDRESS",
+  youre_the_og: "YOU'RE THE OG",
+  app_version: "APP VERSION",
+  security: "SECURITY",
+  revoke_other_installations: "Revoke other installations",
+  revoke_all_other_installations: "Revoke all other installations",
+  revoke_description:
+    "Revoke all other group installations of XMTP on other applications and devices.",
 
   // Attachments
   photo_library: "Photo Library",

--- a/screens/GroupInvite.tsx
+++ b/screens/GroupInvite.tsx
@@ -1,5 +1,5 @@
 import Avatar from "@components/Avatar";
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import { useGroupInviteQuery } from "@queries/useGroupInviteQuery";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";

--- a/screens/NewConversation/NewGroupSummary.tsx
+++ b/screens/NewConversation/NewGroupSummary.tsx
@@ -1,4 +1,4 @@
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import {
   backgroundColor,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "@data/*": ["./data/*"],
       "@hooks/*": ["./hooks/*"],
       "@i18n/*": ["./i18n/*"],
+      "@i18n": ["./i18n/index"],
       "@queries/*": ["./queries/*"],
       "@screens/*": ["./screens/*"],
       "@styles/*": ["./styles/*"],

--- a/utils/reactions.ts
+++ b/utils/reactions.ts
@@ -1,4 +1,4 @@
-import { translate } from "@i18n/index";
+import { translate } from "@i18n";
 import { ContentTypeReaction } from "@xmtp/content-type-reaction";
 
 import { isAttachmentMessage } from "./attachment/helpers";


### PR DESCRIPTION
Added tsconfig to handle index file
Changed all usage of translate to come from index file Fixes cases where first translation may show missing as it is being used before creating the i18n manager