### PR TITLE
Revoke other installations when logging in (temporary feature)

### DIFF
--- a/components/DebugButton.tsx
+++ b/components/DebugButton.tsx
@@ -7,6 +7,8 @@ import {
 } from "@utils/logger";
 import { navigate } from "@utils/navigation";
 import { getNativeLogFile } from "@utils/xmtpRN/logs";
+import { getXmtpClient } from "@utils/xmtpRN/sync";
+import { Client } from "@xmtp/react-native-sdk";
 import axios from "axios";
 import Constants from "expo-constants";
 import { Image } from "expo-image";
@@ -80,6 +82,18 @@ const DebugButton = forwardRef((props, ref) => {
             return Alert.alert("No previous session logging file found");
           }
           navigate("WebviewPreview", { uri: previousLoggingFile });
+        },
+        "Get installations": async () => {
+          const client = (await getXmtpClient(currentAccount())) as Client;
+          const state = await client.inboxState(true);
+          Alert.alert(
+            `${state.installationIds.length} installations`,
+            `InboxId: ${client.inboxId}\n\nCurrent installation: ${
+              client.installationId
+            }\n\nAll installations:\n\n${state.installationIds
+              .map((i) => `${i}`)
+              .join("\n\n")}`
+          );
         },
         "Trigger OTA Update": async () => {
           try {

--- a/components/Onboarding/ConnectViaWallet.tsx
+++ b/components/Onboarding/ConnectViaWallet.tsx
@@ -1,6 +1,7 @@
 import { translate } from "@i18n";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { textPrimaryColor, textSecondaryColor } from "@styles/colors";
+import { awaitableAlert } from "@utils/alert";
 import { getDatabaseFilesForInboxId } from "@utils/fileSystem";
 import logger from "@utils/logger";
 import { sentryTrackMessage } from "@utils/sentry";
@@ -215,6 +216,13 @@ export default function ConnectViaWallet({
       const base64Key = await getXmtpBase64KeyFromSigner(
         signer,
         async () => {
+          await awaitableAlert(
+            translate("current_installation_revoked"),
+            translate("current_installation_revoked_description")
+          );
+          disconnect();
+        },
+        async () => {
           logger.debug("Asking for create signature");
           // Before calling "create" signature
           setWaitingForNextSignature(true);
@@ -254,6 +262,7 @@ export default function ConnectViaWallet({
           }
         }
       );
+      if (!base64Key) return;
       logger.debug("Got base64 key, now connecting");
       await connectWithBase64Key(base64Key);
       logger.info("Successfully logged in using a wallet");
@@ -269,6 +278,7 @@ export default function ConnectViaWallet({
     address,
     alreadyV3Db,
     connectWithBase64Key,
+    disconnect,
     onXmtp,
     setLoading,
     signer,

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -59,8 +59,7 @@ const en = {
   current_installation_revoked_description:
     "The current installation has been revoked, you will now get logged out and group chats will be deleted",
   other_installations_count: "You have {{count}} other installations",
-  temporary_revoke_description:
-    "Temporary debugging feature: we will revoke those installations now",
+  temporary_revoke_description: "Can we revoke those installations now?",
 
   // Attachments
   photo_library: "Photo Library",

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -55,10 +55,12 @@ const en = {
   youre_the_og: "YOU'RE THE OG",
   app_version: "APP VERSION",
   security: "SECURITY",
-  revoke_other_installations: "Revoke other installations",
-  revoke_all_other_installations: "Revoke all other installations",
-  revoke_description:
-    "Revoke all other V3 installations of XMTP on other applications and devices.",
+  current_installation_revoked: "Installation revoked",
+  current_installation_revoked_description:
+    "The current installation has been revoked, you will now get logged out and group chats will be deleted",
+  other_installations_count: "You have {{count}} other installations",
+  temporary_revoke_description:
+    "Temporary debugging feature: we will revoke those installations now",
 
   // Attachments
   photo_library: "Photo Library",

--- a/screens/Main.tsx
+++ b/screens/Main.tsx
@@ -1,5 +1,6 @@
 import UserProfile from "@components/Onboarding/UserProfile";
 import { backgroundColor } from "@styles/colors";
+import { useCheckCurrentInstallation } from "@utils/xmtpRN/client";
 import { StatusBar } from "expo-status-bar";
 import React, { useCallback, useEffect, useRef } from "react";
 import { Dimensions, Platform, useColorScheme } from "react-native";
@@ -34,6 +35,7 @@ export default function Main() {
   // Makes sure we have a Privy token ready to make API calls
   usePrivyAccessToken();
   useAddressBookStateHandler();
+  useCheckCurrentInstallation();
   const colorScheme = useColorScheme();
   const userAddress = useCurrentAccount();
   const socials = useProfilesStore((s) =>

--- a/screens/Onboarding.tsx
+++ b/screens/Onboarding.tsx
@@ -1,7 +1,7 @@
 import { translate } from "@i18n/index";
 import { awaitableAlert } from "@utils/alert";
 import logger from "@utils/logger";
-import { sentryAddBreadcrumb, sentryTrackMessage } from "@utils/sentry";
+import { sentryTrackMessage } from "@utils/sentry";
 import { useCallback, useEffect, useRef } from "react";
 
 import ConnectViaWallet from "../components/Onboarding/ConnectViaWallet";
@@ -53,25 +53,25 @@ export default function Onboarding() {
 
   const connectWithBase64Key = useCallback(
     async (base64Key: string) => {
-      sentryAddBreadcrumb("In connectWithBase64Key");
+      logger.debug("In connectWithBase64Key");
       if (!address) {
         sentryTrackMessage("Could not connect because no address");
         return;
       }
-      sentryAddBreadcrumb("Waiting for logout tasks");
+      logger.debug("Waiting for logout tasks");
       await waitForLogoutTasksDone(500);
-      sentryAddBreadcrumb("Logout tasks done, saving xmtp key");
+      logger.debug("Logout tasks done, saving xmtp key");
       await saveXmtpKey(address, base64Key);
-      sentryAddBreadcrumb("XMTP Key saved");
+      logger.debug("XMTP Key saved");
       // Successfull login for user, let's setup
       // the storage !
       useAccountsStore.getState().setCurrentAccount(address, true);
       if (connectionMethod === "phone" && privyAccountId) {
         useAccountsStore.getState().setPrivyAccountId(address, privyAccountId);
       }
-      sentryAddBreadcrumb("Initiating converse db");
+      logger.debug("Initiating converse db");
       await initDb(address);
-      sentryAddBreadcrumb("Refreshing profiles");
+      logger.debug("Refreshing profiles");
       await refreshProfileForAddress(address, address);
       // Now we can really set!
       useAccountsStore.getState().setCurrentAccount(address, false);

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -14,7 +14,6 @@ import {
 } from "@styles/colors";
 import { PictoSizes } from "@styles/sizes";
 import { memberCanUpdateGroup } from "@utils/groupUtils/memberCanUpdateGroup";
-import { revokeOtherInstallations } from "@utils/xmtpRN/client";
 import Constants from "expo-constants";
 import * as Linking from "expo-linking";
 import React, { useCallback, useEffect, useMemo, useState } from "react";

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -330,38 +330,6 @@ export default function ProfileScreen({
     );
   }, [colorScheme, logout]);
 
-  const showRevokeActionSheet = useCallback(async () => {
-    if (Platform.OS === "web") {
-      // Fixes double action sheet on web
-      await new Promise((r) => setTimeout(r, 100));
-    }
-    const methods = {
-      [translate("revoke_other_installations")]: () =>
-        revokeOtherInstallations(userAddress),
-      [translate("cancel")]: () => {},
-    };
-
-    const options = Object.keys(methods);
-
-    showActionSheetWithOptions(
-      {
-        options,
-        title: translate("revoke_all_other_installations"),
-        message: translate("revoke_description"),
-        cancelButtonIndex: options.indexOf(translate("cancel")),
-        destructiveButtonIndex: [0],
-        ...actionSheetColors(colorScheme),
-      },
-      (selectedIndex?: number) => {
-        if (selectedIndex === undefined) return;
-        const method = (methods as any)[options[selectedIndex]];
-        if (method) {
-          method();
-        }
-      }
-    );
-  }, [colorScheme, userAddress]);
-
   const actionsTableViewItems = useMemo(() => {
     const items: TableViewItemType[] = [];
     if (!isBlockedPeer) {

--- a/utils/alert.ts
+++ b/utils/alert.ts
@@ -1,19 +1,28 @@
-import { Alert } from "react-native";
+import { Alert, AlertButton } from "react-native";
 
-export const awaitableAlert = async (title: string, message?: string) => {
-  await new Promise((resolve) => {
-    Alert.alert(
-      title,
-      message,
-      [
-        {
-          text: "Ok",
-          onPress: () => {
-            resolve("YES");
-          },
+export const awaitableAlert = (
+  title: string,
+  message?: string,
+  okButton?: string,
+  cancelButton?: string
+): Promise<boolean> =>
+  new Promise((resolve) => {
+    const buttons: AlertButton[] = [
+      {
+        text: okButton || "Ok",
+        onPress: () => {
+          resolve(true);
         },
-      ],
-      { cancelable: false }
-    );
+        isPreferred: true,
+      },
+    ];
+    if (cancelButton) {
+      buttons.unshift({
+        text: cancelButton,
+        onPress: () => {
+          resolve(false);
+        },
+      });
+    }
+    Alert.alert(title, message, buttons, { cancelable: false });
   });
-};

--- a/utils/alert.ts
+++ b/utils/alert.ts
@@ -1,0 +1,19 @@
+import { Alert } from "react-native";
+
+export const awaitableAlert = async (title: string, message?: string) => {
+  await new Promise((resolve) => {
+    Alert.alert(
+      title,
+      message,
+      [
+        {
+          text: "Ok",
+          onPress: () => {
+            resolve("YES");
+          },
+        },
+      ],
+      { cancelable: false }
+    );
+  });
+};

--- a/utils/fileSystem/index.ts
+++ b/utils/fileSystem/index.ts
@@ -62,6 +62,14 @@ export const copyDatabasesToTemporaryDirectory = async (
   }
 };
 
+export const deleteLibXmtpDatabaseForInboxId = async (inboxId: string) => {
+  const dbDirectoryXmtpDbFiles = await getDatabaseFilesForInboxId(inboxId);
+  for (const dbFile of dbDirectoryXmtpDbFiles) {
+    logger.debug("Deleting database file", dbFile.name);
+    await RNFS.unlink(dbFile.path);
+  }
+};
+
 export const moveTemporaryDatabasesToDatabaseDirecory = async (
   tempDirectory: string,
   inboxId: string

--- a/utils/xmtpRN/client.ts
+++ b/utils/xmtpRN/client.ts
@@ -1,4 +1,5 @@
 import { useCurrentAccount } from "@data/store/accountsStore";
+import { translate } from "@i18n";
 import { awaitableAlert } from "@utils/alert";
 import { getDbEncryptionKey } from "@utils/keychain/helpers";
 import logger from "@utils/logger";
@@ -111,8 +112,8 @@ export const useCheckCurrentInstallation = () => {
       if (!inboxState.installationIds.includes(client.installationId)) {
         logger.warn(`Installation ${client.installationId} has been revoked`);
         await awaitableAlert(
-          "Installation revoked",
-          "The current installation has been revoked, you will now get logged out and group chats will be deleted"
+          translate("current_installation_revoked"),
+          translate("current_installation_revoked_description")
         );
         logout(true);
         accountCheck.current = undefined;

--- a/utils/xmtpRN/signIn.ts
+++ b/utils/xmtpRN/signIn.ts
@@ -1,3 +1,4 @@
+import { translate } from "@i18n";
 import { awaitableAlert } from "@utils/alert";
 import {
   copyDatabasesToTemporaryDirectory,
@@ -93,8 +94,10 @@ const revokeOtherInstallations = async (
     if (showAlert) {
       // We're on a mobile wallet so we need to ask the user first
       await awaitableAlert(
-        `You have ${otherInstallations.length} other installations`,
-        "Temporary debugging feature: we will revoke those installations now"
+        translate("other_installations_count", {
+          count: otherInstallations.length,
+        }),
+        translate("temporary_revoke_description")
       );
     }
     /* On iOS, when we leave the app, it will automatically disconnect db

--- a/utils/xmtpRN/signIn.ts
+++ b/utils/xmtpRN/signIn.ts
@@ -1,12 +1,15 @@
+import { awaitableAlert } from "@utils/alert";
 import {
   copyDatabasesToTemporaryDirectory,
   createTemporaryDirectory,
-  moveTemporaryDatabasesToDatabaseDirecory,
+  moveTemporaryDatabasesToDatabaseDirecory as moveTemporaryDatabasesToDatabaseDirectory,
 } from "@utils/fileSystem";
 import { getDbEncryptionKey } from "@utils/keychain/helpers";
+import logger from "@utils/logger";
 import { sentryAddBreadcrumb } from "@utils/sentry";
 import { Client } from "@xmtp/react-native-sdk";
 import { Signer } from "ethers";
+import { AppState } from "react-native";
 
 import config from "../../config";
 
@@ -52,10 +55,70 @@ export const getXmtpBase64KeyFromSigner = async (
 
   sentryAddBreadcrumb("Instantiated client from signer, exporting key bundle");
   const base64Key = await client.exportKeyBundle();
+
+  const isConnectingViaWallet =
+    !!preCreateIdentityCallback ||
+    !!preEnableIdentityCallback ||
+    !!preAuthenticateToInboxCallback;
+  await revokeOtherInstallations(signer, client, isConnectingViaWallet);
+
   // This Client is only be used to extract the key, we can disconnect
   // it to prevent locks happening during Onboarding
   await client.dropLocalDatabaseConnection();
-  await moveTemporaryDatabasesToDatabaseDirecory(tempDirectory, client.inboxId);
+  await moveTemporaryDatabasesToDatabaseDirectory(
+    tempDirectory,
+    client.inboxId
+  );
   sentryAddBreadcrumb("Exported key bundle");
   return base64Key;
+};
+
+/*
+Temporary method for XMTP team to revoke other installations
+when logging in to remove weird, broken installation
+*/
+const revokeOtherInstallations = async (
+  signer: Signer,
+  client: Client,
+  showAlert: boolean
+) => {
+  const state = await client.inboxState(true);
+  logger.warn(
+    `Inbox ${client.inboxId} has ${state.installationIds.length} installations`
+  );
+  const otherInstallations = state.installationIds.filter(
+    (installationId) => installationId !== client.installationId
+  );
+  if (otherInstallations.length > 0) {
+    if (showAlert) {
+      // We're on a mobile wallet so we need to ask the user first
+      await awaitableAlert(
+        `You have ${otherInstallations.length} other installations`,
+        "Temporary debugging feature: we will revoke those installations now"
+      );
+    }
+    /* On iOS, when we leave the app, it will automatically disconnect db
+    and might not reconect fast enough when coming back from that signature
+    and hit "Client error: storage error: Pool needs to  reconnect before use"
+    We should find a long term solution but in the meantime making sure we reconnect!
+    */
+    const reconnectWhenBackgrounded = AppState.addEventListener(
+      "change",
+      (state) => {
+        if (state.match(/inactive|background/)) {
+          reconnectWhenBackgrounded.remove();
+          // We don't really know when database will be disconnected so
+          // might as well try a few times...
+          client.reconnectLocalDatabase();
+          setTimeout(() => {
+            client.reconnectLocalDatabase();
+          }, 500);
+          setTimeout(() => {
+            client.reconnectLocalDatabase();
+          }, 1000);
+        }
+      }
+    );
+    await client.revokeAllOtherInstallations(signer);
+  }
 };

--- a/utils/xmtpRN/signIn.ts
+++ b/utils/xmtpRN/signIn.ts
@@ -109,12 +109,15 @@ const revokeOtherInstallations = async (
     );
     if (showAlert) {
       // We're on a mobile wallet so we need to ask the user first
-      await awaitableAlert(
+      const doRevoke = await awaitableAlert(
         translate("other_installations_count", {
           count: otherInstallations.length,
         }),
-        translate("temporary_revoke_description")
+        translate("temporary_revoke_description"),
+        "Yes",
+        "No"
       );
+      if (!doRevoke) return;
     }
     /* On iOS, when we leave the app, it will automatically disconnect db
     and might not reconect fast enough when coming back from that signature

--- a/utils/xmtpRN/sync.ts
+++ b/utils/xmtpRN/sync.ts
@@ -93,7 +93,6 @@ const onSyncLost = async (account: string, error: any) => {
       logger.error(
         "Reconnecting XMTP Pool because it didn't reconnect automatically"
       );
-      console.log("reconnecting!!");
       await reconnectXmtpClientsDbConnections();
     } else if (AppState.currentState === "background") {
       // This error is normal when backgrounded, fail silently


### PR DESCRIPTION
- When logging in, we want to revoke other installations because many of them are broken
- Also implements a check to logout user from other devices if installation has been revoked
- + check during onboarding if logging in with an existing libxmtp database but installation has been revoked

N.B. : due to the fact that we disconnect the XMTP db when leaving the app, I hit issues with `Client error: storage error: Pool needs to  reconnect before use` when coming back to the app after the revoke signature. 

Since this is a temporary debug feature for now, I implemented an ugly fix (reconnecting the database in this specific case when we leave the app). We can do that since during the onboading the db is not in the shared container.

But we will hit this kind of issues in the future:
- when revoking installations from the settings page (not the onboarding)
- when adding new EOA / SCW
- any feature that requires a signature and has an impact in the libxmtp database

I think we need a way to "wait and retry" when we hit a `Client error: storage error: Pool needs to  reconnect before use`
This will probably need to be done in libxmtp?

Also: revoked devices will need to "logout & delete libxmtp database", if not they will re-login next time with the same installation key. Should we implement a "logout & delete installation" while keeping group history?

cc @neekolas @nplasterer 