### PR TITLE
Improve iOS Navigation Bar and Syncing Error Handling

### DIFF
--- a/components/Connecting.tsx
+++ b/components/Connecting.tsx
@@ -95,7 +95,7 @@ export const useShouldShowConnectingOrSyncing = () => {
   }, [conversations, initialLoadDoneOnce]);
 
   return (
-    shouldShowConnecting ||
+    shouldShowConnecting.shouldShow ||
     (!initialLoadDoneOnce && Object.keys(conversations).length > 0)
   );
 };

--- a/screens/Navigation/ConversationListNav.ios.tsx
+++ b/screens/Navigation/ConversationListNav.ios.tsx
@@ -20,6 +20,7 @@ import {
   navigationAnimation,
 } from "./Navigation";
 import Connecting, {
+  useShouldShowConnecting,
   useShouldShowConnectingOrSyncing,
 } from "../../components/Connecting";
 import NewConversationButton from "../../components/ConversationList/NewConversationButton";
@@ -27,7 +28,7 @@ import ProfileSettingsButton from "../../components/ConversationList/ProfileSett
 import { useAccountsStore, useChatStore } from "../../data/store/accountsStore";
 import { useSelect } from "../../data/store/storeHelpers";
 import { isDesktop } from "../../utils/device";
-import { getReadableProfile } from "../../utils/str";
+import { getReadableProfile, shortDisplayName } from "../../utils/str";
 import ConversationList from "../ConversationList";
 
 type HeaderSearchBarProps = {
@@ -77,6 +78,7 @@ export default function ConversationListNav() {
   ) as React.MutableRefObject<SearchBarCommands | null>;
 
   const shouldShowConnectingOrSyncing = useShouldShowConnectingOrSyncing();
+  const shouldShowConnecting = useShouldShowConnecting();
   const shouldShowError = useShouldShowErrored();
   const currentAccount = useAccountsStore((s) => s.currentAccount);
   const name = getReadableProfile(currentAccount, currentAccount);
@@ -89,6 +91,11 @@ export default function ConversationListNav() {
           shouldShowConnectingOrSyncing ? (
             <View style={styles.connectingContainer}>
               {shouldShowConnectingOrSyncing && <Connecting />}
+              {shouldShowConnecting.warnMessage && (
+                <Text style={styles.warn}>
+                  {shouldShowConnecting.warnMessage}
+                </Text>
+              )}
             </View>
           ) : (
             <View />
@@ -126,7 +133,9 @@ export default function ConversationListNav() {
                     },
                   ]}
                 >
-                  {name}
+                  {shouldShowConnecting.warnMessage
+                    ? shortDisplayName(name)
+                    : name}
                 </Text>
                 {shouldShowError && <ErroredHeader />}
               </View>
@@ -144,7 +153,12 @@ export default function ConversationListNav() {
 
 const styles = StyleSheet.create({
   connectingContainer: {
-    marginTop: -10,
+    marginTop: -5,
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  warn: {
+    marginLeft: 8,
   },
   headerRight: {
     marginTop: -10,

--- a/screens/Navigation/ConversationListNav.tsx
+++ b/screens/Navigation/ConversationListNav.tsx
@@ -80,7 +80,7 @@ export default function ConversationListNav() {
   const onChangeSearch = (query: string) => setSearchQuery(query);
   const searchPlaceholder = (): string => {
     if (shouldShowConnectingOrSyncing && !searchBarFocused) {
-      return shouldShowConnecting ? "Connecting…" : "Syncing…";
+      return shouldShowConnecting.shouldShow ? "Connecting…" : "Syncing…";
     }
     return "Search chats";
   };

--- a/utils/str.test.ts
+++ b/utils/str.test.ts
@@ -8,7 +8,6 @@ import {
   getReadableProfile,
   getTitleFontScale,
   shortAddress,
-  shortDomain,
   strByteSize,
 } from "./str";
 import { getProfilesStore } from "../data/store/accountsStore";
@@ -58,19 +57,19 @@ describe("shortAddress", () => {
   });
 });
 
-describe("shortDomain", () => {
+describe("shortdisplayName", () => {
   it("should shorten the domain correctly based on screen width", () => {
-    expect(shortDomain("thisisaverylongdomainname.com")).toBe(
+    expect(shortdisplayName("thisisaverylongdomainname.com")).toBe(
       "thisisaverylong..."
     );
   });
 
   it("should return the original domain if shorter than maxLength", () => {
-    expect(shortDomain("short.com")).toBe("short.com");
+    expect(shortdisplayName("short.com")).toBe("short.com");
   });
 
   it("should return an empty string if domain is undefined", () => {
-    expect(shortDomain(undefined)).toBe("");
+    expect(shortdisplayName(undefined)).toBe("");
   });
 });
 

--- a/utils/str.test.ts
+++ b/utils/str.test.ts
@@ -7,6 +7,7 @@ import {
   formatGroupName,
   getReadableProfile,
   getTitleFontScale,
+  shortDisplayName,
   shortAddress,
   strByteSize,
 } from "./str";
@@ -57,19 +58,19 @@ describe("shortAddress", () => {
   });
 });
 
-describe("shortdisplayName", () => {
+describe("shortDisplayName", () => {
   it("should shorten the domain correctly based on screen width", () => {
-    expect(shortdisplayName("thisisaverylongdomainname.com")).toBe(
+    expect(shortDisplayName("thisisaverylongdomainname.com")).toBe(
       "thisisaverylong..."
     );
   });
 
   it("should return the original domain if shorter than maxLength", () => {
-    expect(shortdisplayName("short.com")).toBe("short.com");
+    expect(shortDisplayName("short.com")).toBe("short.com");
   });
 
   it("should return an empty string if domain is undefined", () => {
-    expect(shortdisplayName(undefined)).toBe("");
+    expect(shortDisplayName(undefined)).toBe("");
   });
 });
 

--- a/utils/str.ts
+++ b/utils/str.ts
@@ -17,9 +17,9 @@ export const shortAddress = (address: string) =>
       )}`
     : address || "";
 
-export const shortDomain = (domain: string | undefined): string => {
-  if (!domain) return "";
-  if (Platform.OS === "web") return domain;
+export const shortDisplayName = (displayName: string | undefined): string => {
+  if (!displayName) return "";
+  if (Platform.OS === "web") return displayName;
 
   const screenWidth = Dimensions.get("window").width;
   let maxLength;
@@ -35,9 +35,9 @@ export const shortDomain = (domain: string | undefined): string => {
     maxLength = 12;
   }
 
-  return domain.length > maxLength
-    ? `${domain.slice(0, maxLength)}...`
-    : domain;
+  return displayName.length > maxLength
+    ? `${displayName.slice(0, maxLength)}...`
+    : displayName;
 };
 
 export const capitalize = (str: string) => str[0].toUpperCase() + str.slice(1);


### PR DESCRIPTION
Description:

- Warning Messages: Implemented warnings that inform users of potential issues during syncing or loading. On iOS, these messages appear when waiting for network, reconnecting, or syncing for more than 15 seconds
- String Shortening: Recycled a helper method to gracefully shorten strings in the navigation bar, preventing overflow when it becomes too populated

Impact:
1. Enhances UI clarity by managing long strings in the navigation bar.
2. Improves user awareness of app status during network or syncing issues.

Fixes #353 

**Screenshots**

Regular loading (below 15 seconds and without ongoing errors):
![IMG_1186](https://github.com/user-attachments/assets/bd0ef4dc-9564-4011-8bb5-be95fc0275f3)

Reconnecting:
![IMG_1185](https://github.com/user-attachments/assets/977d9987-ad86-41a4-98b1-226b22824863)

With long user name, shorten, as seen on iPhone 13 Mini (smallest screen width on iOS)
![IMG_1187](https://github.com/user-attachments/assets/8889b77b-aba8-4abe-b9e0-544c25dc8b6a)

Waiting for network:
![Waiting](https://github.com/user-attachments/assets/fb55fdbb-1d33-435d-aac3-7c2d75e23995)
