### PR TITLE
fix: Don't show pending requests for users already in the group

### DIFF
--- a/hooks/useGroupPendingRequests.ts
+++ b/hooks/useGroupPendingRequests.ts
@@ -3,20 +3,25 @@ import { PendingGroupJoinRequest } from "@utils/api";
 import { useMemo } from "react";
 
 import { useExistingGroupInviteLink } from "./useExistingGroupInviteLink";
+import { useGroupMembers } from "./useGroupMembers";
 
 export const useGroupPendingRequests = (topic: string) => {
   const { data } = usePendingRequestsQuery();
+  const { members } = useGroupMembers(topic);
   const groupInviteLink = useExistingGroupInviteLink(topic);
   const requests = useMemo(() => {
     if (!data || !data.joinRequests) return [];
     const addressMap = new Map<string, PendingGroupJoinRequest>();
     for (const joinRequest of data.joinRequests) {
-      if (groupInviteLink?.includes(joinRequest.groupInviteLinkId)) {
+      if (
+        groupInviteLink?.includes(joinRequest.groupInviteLinkId) &&
+        !members?.byAddress[joinRequest.requesterAddress]
+      ) {
         addressMap.set(joinRequest.requesterAddress, joinRequest);
       }
     }
     return Array.from(addressMap);
-  }, [data, groupInviteLink]);
+  }, [data, groupInviteLink, members]);
 
   return requests;
 };

--- a/utils/groupInvites.ts
+++ b/utils/groupInvites.ts
@@ -2,6 +2,7 @@ import mmkv from "./mmkv";
 
 const GROUP_INVITE_LINKS_STORAGE_KEY_PREFIX = "group-invites-link-";
 const INVITE_ID_BY_GROUP_ID_STORAGE_KEY_PREFIX = "invite-id-by-group-id-";
+const GROUP_JOIN_REQUEST_STORAGE_KEY_PREFIX = "group-join-request-";
 
 export const createGroupInviteLinkStoragekey = (inviteId: string) => {
   return `${GROUP_INVITE_LINKS_STORAGE_KEY_PREFIX}${inviteId}`;
@@ -33,4 +34,24 @@ export const getInviteIdByGroupId = (groupId: string) => {
 
 export const deleteInviteIdByGroupId = (groupId: string) => {
   return mmkv.delete(createInviteIdByGroupIdStorageKey(groupId));
+};
+
+const createGroupJoinStorageKey = (account: string, inviteId: string) => {
+  return `${GROUP_JOIN_REQUEST_STORAGE_KEY_PREFIX}${inviteId}-${account}`;
+};
+
+export const saveInviteJoinRequest = (
+  account: string,
+  inviteId: string,
+  joinRequestId: string
+) => {
+  return mmkv.set(createGroupJoinStorageKey(account, inviteId), joinRequestId);
+};
+
+export const getInviteJoinRequest = (account: string, inviteId: string) => {
+  return mmkv.getString(createGroupJoinStorageKey(account, inviteId));
+};
+
+export const deleteInviteJoinRequest = (account: string, inviteId: string) => {
+  return mmkv.delete(createGroupJoinStorageKey(account, inviteId));
 };


### PR DESCRIPTION
Filter out requests that have already been approved but not updated on the backend Set storage so users can only attempt to join once from app installation perspective

Closes https://github.com/ephemeraHQ/converse-app/issues/584 
Closes https://github.com/ephemeraHQ/converse-app/issues/588