### PR TITLE
Stop showing recommended profiles while creating a group chat

### DIFF
--- a/screens/NewConversation/NewConversation.tsx
+++ b/screens/NewConversation/NewConversation.tsx
@@ -408,7 +408,7 @@ export default function NewConversation({
         </View>
       )}
 
-      {isEmptyObject(status.profileSearchResults) && (
+      {isEmptyObject(status.profileSearchResults) && !group.enabled && (
         <View
           style={{
             backgroundColor: backgroundColor(colorScheme),


### PR DESCRIPTION
Now hiding recommended profiles while creating a group chat. Closes #346

![IMG_1208](https://github.com/user-attachments/assets/0c55c8f6-a32d-46d4-a73a-e2603f21e7d8)

![IMG_1209](https://github.com/user-attachments/assets/921199b4-b6ce-40cb-a159-95729f574259)
