### PR TITLE
fix: Android Dark mode inner bubble colors

### DIFF
--- a/styles/colors/index.ts
+++ b/styles/colors/index.ts
@@ -121,7 +121,7 @@ const MESSAGE_INNER_BUBBLE_DARK = "rgba(235, 235, 245, 0.3)";
 export const messageInnerBubbleColor = (colorScheme: ColorSchemeName) => {
   if (colorScheme === "dark")
     return Platform.OS === "android" || Platform.OS === "web"
-      ? MaterialDarkColors.inverseSurface
+      ? MaterialDarkColors.inverseOnSurface
       : MESSAGE_INNER_BUBBLE_DARK;
   return Platform.OS === "android" || Platform.OS === "web"
     ? MaterialLightColors.inverseSurface


### PR DESCRIPTION
Updated inner color bubble color

![image](https://github.com/user-attachments/assets/941e4b8f-3d8c-440c-94fb-e572a48590c5)