### PR TITLE
Reorg and add logs to debug failing onboardings

### DIFF
--- a/components/Onboarding/WalletSelector.tsx
+++ b/components/Onboarding/WalletSelector.tsx
@@ -138,6 +138,9 @@ export default function WalletSelector() {
               action: async () => {
                 setLoading(true);
                 setConnectionMethod("wallet");
+                logger.debug(
+                  `[Onboarding] Clicked on wallet ${w.name} - opening external app`
+                );
                 try {
                   if (w.name === "Coinbase Wallet") {
                     thirdwebConnect(async () => {

--- a/components/XmtpEngine.tsx
+++ b/components/XmtpEngine.tsx
@@ -72,6 +72,9 @@ export default function XmtpEngine() {
     const subscription = AppState.addEventListener(
       "change",
       async (nextAppState) => {
+        logger.debug(
+          `[AppState] App is was ${appState.current} - now ${nextAppState}`
+        );
         if (
           nextAppState === "active" &&
           appState.current.match(/inactive|background/)

--- a/utils/xmtpRN/signIn.ts
+++ b/utils/xmtpRN/signIn.ts
@@ -107,7 +107,13 @@ const revokeOtherInstallations = async (signer: Signer, client: Client) => {
       "Yes",
       "No"
     );
-    if (!doRevoke) return;
+    if (!doRevoke) {
+      logger.debug(`[Onboarding] User decided not to revoke`);
+      return;
+    }
+    logger.debug(
+      `[Onboarding] User decided to revoke ${otherInstallations.length} installation`
+    );
     /* On iOS, when we leave the app, it will automatically disconnect db
     and might not reconect fast enough when coming back from that signature
     and hit "Client error: storage error: Pool needs to  reconnect before use"
@@ -131,5 +137,6 @@ const revokeOtherInstallations = async (signer: Signer, client: Client) => {
       }
     );
     await client.revokeAllOtherInstallations(signer);
+    logger.debug(`[Onboarding] Installations revoked.`);
   }
 };


### PR DESCRIPTION
Seems that we have a regression on some onboarding infinite spinner
Trying to add more logs to see if it comes from us

It could also be an XMTP issue (I hit rate limiting once…) or a walletconnect issue (but I haven't managed to add wc specific logs yet)