### PR TITLE
Profiles to React Queries

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -17,7 +17,7 @@ import {
 import { Indicator } from "./Indicator";
 import Picto from "./Picto/Picto";
 
-type Props = {
+export type AvatarProps = {
   uri?: string | undefined;
   size?: number | undefined;
   style?: StyleProp<ImageStyle>;
@@ -36,7 +36,7 @@ function Avatar({
   name,
   showIndicator,
   invertColor,
-}: Props) {
+}: AvatarProps) {
   const colorScheme = useColorScheme();
   const styles = getStyles(colorScheme, size, invertColor || false);
   const firstLetter = getFirstLetterForAvatar(name || "");

--- a/components/ConversationListItem.tsx
+++ b/components/ConversationListItem.tsx
@@ -41,11 +41,11 @@ import Animated, {
   runOnJS,
 } from "react-native-reanimated";
 
-import Avatar from "./Avatar";
 import { ConversationContextMenu } from "./ConversationContextMenu";
 import GroupAvatar from "./GroupAvatar";
 import Picto from "./Picto/Picto";
 import { showActionSheetWithOptions } from "./StateHandlers/ActionSheetStateHandler";
+import { ConnectedAvatar } from "../containers/ConnectedAvatar";
 import {
   currentAccount,
   useChatStore,
@@ -258,15 +258,14 @@ const ConversationListItem = memo(function ConversationListItem({
         onConversationListScreen
       />
     ) : (
-      <Avatar
+      <ConnectedAvatar
         size={AvatarSizes.conversationListItem}
         style={styles.avatarWrapper}
-        uri={conversationPeerAvatar}
-        name={conversationName}
+        peerAddress={conversationPeerAddress!}
       />
     );
   }, [
-    conversationName,
+    conversationPeerAddress,
     conversationPeerAvatar,
     conversationTopic,
     isGroupConversation,

--- a/containers/ConnectedAvatar.tsx
+++ b/containers/ConnectedAvatar.tsx
@@ -1,0 +1,23 @@
+import Avatar, { AvatarProps } from "@components/Avatar";
+import { useProfileSocials } from "@hooks/useProfileSocials";
+import { getPreferredAvatar, getPreferredName } from "@utils/profile";
+import { FC } from "react";
+
+interface ConnectedAvatarProps
+  extends Pick<
+    AvatarProps,
+    "size" | "style" | "color" | "showIndicator" | "invertColor"
+  > {
+  peerAddress: string;
+}
+
+export const ConnectedAvatar: FC<ConnectedAvatarProps> = ({
+  peerAddress,
+  ...avatarProps
+}) => {
+  const { data } = useProfileSocials(peerAddress);
+
+  const preferredAvatar = data ? getPreferredAvatar(data) : undefined;
+  const preferredName = data ? getPreferredName(data, peerAddress) : undefined;
+  return <Avatar uri={preferredAvatar} name={preferredName} {...avatarProps} />;
+};

--- a/containers/GroupPendingRequestsTable.tsx
+++ b/containers/GroupPendingRequestsTable.tsx
@@ -1,7 +1,8 @@
 import { showActionSheetWithOptions } from "@components/StateHandlers/ActionSheetStateHandler";
 import { TableViewPicto } from "@components/TableView/TableViewImage";
-import { useCurrentAccount, useProfilesStore } from "@data/store/accountsStore";
+import { useCurrentAccount } from "@data/store/accountsStore";
 import { useGroupPendingRequests } from "@hooks/useGroupPendingRequests";
+import { usePreferredNames } from "@hooks/usePreferredNames";
 import { translate } from "@i18n";
 import { useAddToGroupMutation } from "@queries/useAddToGroupMutation";
 import { invalidatePendingJoinRequestsQuery } from "@queries/usePendingRequestsQuery";
@@ -26,20 +27,18 @@ export const GroupPendingRequestsTable: FC<GroupPendingRequestsTableProps> = ({
   const currentAccount = useCurrentAccount() as string;
   const styles = useStyles();
   const requests = useGroupPendingRequests(topic);
-  const profiles = useProfilesStore((s) => s.profiles);
+  const addresses = useMemo(() => requests.map((a) => a[0]), [requests]);
+  const preferredNames = usePreferredNames(addresses);
   const { mutateAsync: addToGroup } = useAddToGroupMutation(
     currentAccount,
     topic
   );
   const tableViewItems = useMemo(() => {
     const items: TableViewItemType[] = [];
-    requests.forEach((a) => {
+    requests.forEach((a, id) => {
       const address = a[0];
       const request = a[1];
-      const preferredName = getPreferredName(
-        getProfile(address, profiles)?.socials,
-        address
-      );
+      const preferredName = preferredNames[id];
       items.push({
         id: address,
         title: preferredName,
@@ -101,7 +100,7 @@ export const GroupPendingRequestsTable: FC<GroupPendingRequestsTableProps> = ({
     addToGroup,
     colorScheme,
     currentAccount,
-    profiles,
+    preferredNames,
     requests,
     styles.adminText,
     styles.tableViewRight,

--- a/data/helpers/profiles/profilesUpdate.ts
+++ b/data/helpers/profiles/profilesUpdate.ts
@@ -50,7 +50,14 @@ export const refreshProfileForAddress = async (
   const now = new Date().getTime();
   const profilesByAddress = await getProfilesForAddresses([address]);
   // Save profiles to db
-
+  getProfilesStore(account)
+    .getState()
+    .setProfiles({
+      [address]: {
+        socials: profilesByAddress[address],
+        updatedAt: now,
+      },
+    });
   setProfileSocialsQueryData(account, address, profilesByAddress[address], now);
 };
 

--- a/data/helpers/profiles/profilesUpdate.ts
+++ b/data/helpers/profiles/profilesUpdate.ts
@@ -1,3 +1,4 @@
+import { setProfileSocialsQueryData } from "@queries/useProfileSocialsQuery";
 import { getCleanAddress } from "@utils/evm/address";
 
 import { getProfilesForAddresses } from "../../../utils/api";
@@ -31,7 +32,14 @@ export const updateProfilesForConvos = async (
         updatedAt: now,
       };
     }
-    getProfilesStore(account).getState().setProfiles(socialsToDispatch);
+    for (const peerAddress in socialsToDispatch) {
+      setProfileSocialsQueryData(
+        account,
+        peerAddress,
+        socialsToDispatch[peerAddress].socials,
+        socialsToDispatch[peerAddress].updatedAt
+      );
+    }
   }
 };
 
@@ -43,14 +51,7 @@ export const refreshProfileForAddress = async (
   const profilesByAddress = await getProfilesForAddresses([address]);
   // Save profiles to db
 
-  getProfilesStore(account)
-    .getState()
-    .setProfiles({
-      [address]: {
-        socials: profilesByAddress[address],
-        updatedAt: now,
-      },
-    });
+  setProfileSocialsQueryData(account, address, profilesByAddress[address], now);
 };
 
 export const refreshProfilesIfNeeded = async (account: string) => {

--- a/data/index.ts
+++ b/data/index.ts
@@ -1,8 +1,8 @@
 import "reflect-metadata";
 
+import { setProfileSocialsQueryData } from "@queries/useProfileSocialsQuery";
 import logger from "@utils/logger";
 import { getProfile } from "@utils/profile";
-import { setProfileSocialsQueryData } from "@queries/useProfileSocialsQuery";
 
 import { getRepository } from "./db";
 import { Conversation } from "./db/entities/conversationEntity";
@@ -78,12 +78,16 @@ export const loadDataToContext = async (account: string) => {
 
   const profilesByAddress = getProfilesStore(account).getState().profiles;
   for (const peerAddress in profilesByAddress) {
-    if (!profilesByAddress[peerAddress]) continue;
+    if (
+      !profilesByAddress[peerAddress]?.socials ||
+      !profilesByAddress[peerAddress]?.updatedAt
+    )
+      continue;
     setProfileSocialsQueryData(
       account,
       peerAddress,
-      profilesByAddress[peerAddress]?.socials,
-      profilesByAddress[peerAddress]?.updatedAt
+      profilesByAddress[peerAddress].socials,
+      profilesByAddress[peerAddress].updatedAt
     );
   }
   getChatStore(account)

--- a/data/index.ts
+++ b/data/index.ts
@@ -78,17 +78,15 @@ export const loadDataToContext = async (account: string) => {
 
   const profilesByAddress = getProfilesStore(account).getState().profiles;
   for (const peerAddress in profilesByAddress) {
-    if (
-      !profilesByAddress[peerAddress]?.socials ||
-      !profilesByAddress[peerAddress]?.updatedAt
-    )
-      continue;
-    setProfileSocialsQueryData(
-      account,
-      peerAddress,
-      profilesByAddress[peerAddress].socials,
-      profilesByAddress[peerAddress].updatedAt
-    );
+    const profile = profilesByAddress[peerAddress];
+    if (profile?.socials && profile?.updatedAt) {
+      setProfileSocialsQueryData(
+        account,
+        peerAddress,
+        profile.socials,
+        profile.updatedAt
+      );
+    }
   }
   getChatStore(account)
     .getState()

--- a/data/index.ts
+++ b/data/index.ts
@@ -2,14 +2,15 @@ import "reflect-metadata";
 
 import logger from "@utils/logger";
 import { getProfile } from "@utils/profile";
+import { setProfileSocialsQueryData } from "@queries/useProfileSocialsQuery";
 
 import { getRepository } from "./db";
 import { Conversation } from "./db/entities/conversationEntity";
 import { Message } from "./db/entities/messageEntity";
-import { refreshProfilesIfNeeded } from "./helpers/profiles/profilesUpdate";
 import { xmtpConversationFromDb } from "./mappers";
 import { getChatStore, getProfilesStore } from "./store/accountsStore";
 import { saveXmtpEnv, saveApiURI } from "../utils/sharedData";
+import { refreshProfilesIfNeeded } from "./helpers/profiles/profilesUpdate";
 
 const getTypeormBoolValue = (value: number) => value === 1;
 
@@ -76,6 +77,15 @@ export const loadDataToContext = async (account: string) => {
   });
 
   const profilesByAddress = getProfilesStore(account).getState().profiles;
+  for (const peerAddress in profilesByAddress) {
+    if (!profilesByAddress[peerAddress]) continue;
+    setProfileSocialsQueryData(
+      account,
+      peerAddress,
+      profilesByAddress[peerAddress]?.socials,
+      profilesByAddress[peerAddress]?.updatedAt
+    );
+  }
   getChatStore(account)
     .getState()
     .setConversations(

--- a/hooks/usePreferredName.ts
+++ b/hooks/usePreferredName.ts
@@ -1,0 +1,8 @@
+import { getPreferredName } from "@utils/profile";
+
+import { useProfileSocials } from "./useProfileSocials";
+
+export const usePreferredName = (peerAddress: string) => {
+  const { data } = useProfileSocials(peerAddress);
+  return data ? getPreferredName(data, peerAddress) : peerAddress;
+};

--- a/hooks/usePreferredNames.ts
+++ b/hooks/usePreferredNames.ts
@@ -1,0 +1,22 @@
+import { getPreferredName } from "@utils/profile";
+import { useMemo } from "react";
+
+import { useProfilesSocials } from "./useProfilesSocials";
+
+/**
+ *
+ * @param peerAddress Multiple peer addresses to get their socials
+ * @returns array of preferred names or the address if not found
+ */
+export const usePreferredNames = (peerAddresses: string[]) => {
+  const data = useProfilesSocials(peerAddresses);
+  const names = useMemo(() => {
+    // Not sure how performant this will be, or if we can safely rely on the index
+    // If we can't, we should probably use a Map instead
+    return data.map(({ data: socials }, index) => {
+      const peerAddress = peerAddresses[index];
+      return socials ? getPreferredName(socials, peerAddress) : peerAddress;
+    });
+  }, [data, peerAddresses]);
+  return names;
+};

--- a/hooks/useProfileSocials.ts
+++ b/hooks/useProfileSocials.ts
@@ -1,0 +1,7 @@
+import { useCurrentAccount } from "@data/store/accountsStore";
+import { useProfileSocialsQuery } from "@queries/useProfileSocialsQuery";
+
+export const useProfileSocials = (peerAddress: string) => {
+  const currentAccount = useCurrentAccount();
+  return useProfileSocialsQuery(currentAccount!, peerAddress);
+};

--- a/hooks/useProfilesSocials.ts
+++ b/hooks/useProfilesSocials.ts
@@ -1,0 +1,12 @@
+import { useCurrentAccount } from "@data/store/accountsStore";
+import { useProfileSocialsQueries } from "@queries/useProfileSocialsQuery";
+
+/**
+ *
+ * @param peerAddresses Use multiple peer addresses to get their socials
+ * @returns
+ */
+export const useProfilesSocials = (peerAddresses: string[]) => {
+  const currentAccount = useCurrentAccount();
+  return useProfileSocialsQueries(currentAccount!, peerAddresses);
+};

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@xmtp/proto": "^3.60.0",
     "@xmtp/react-native-sdk": "^2.6.4",
     "@xmtp/xmtp-js": "11.5.0",
+    "@yornaath/batshit": "^0.10.1",
     "amazon-cognito-identity-js": "^6.3.12",
     "axios": "^1.2.1",
     "babel-plugin-transform-remove-console": "^6.9.4",

--- a/queries/QueryKeys.ts
+++ b/queries/QueryKeys.ts
@@ -31,6 +31,9 @@ export enum QueryKeys {
   GROUP_INVITE = "groupInvite",
   GROUP_JOIN_REQUEST = "groupJoinRequest",
   PENDING_JOIN_REQUESTS = "pendingJoinRequests",
+
+  // Profiles
+  PROFILE_SOCIALS = "profileSocials",
 }
 
 export const groupsQueryKey = (account: string) => [QueryKeys.GROUPS, account];
@@ -127,3 +130,8 @@ export const pendingJoinRequestsQueryKey = (account: string) => [
   QueryKeys.PENDING_JOIN_REQUESTS,
   account,
 ];
+
+export const profileSocialsQueryKey = (
+  account: string,
+  peerAddress: string
+) => [QueryKeys.PROFILE_SOCIALS, account, peerAddress];

--- a/queries/useProfileSocialsQuery.ts
+++ b/queries/useProfileSocialsQuery.ts
@@ -1,0 +1,88 @@
+import { ProfileSocials } from "@data/store/profilesStore";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { getProfilesForAddresses } from "@utils/api";
+import logger from "@utils/logger";
+import {
+  create,
+  windowedFiniteBatchScheduler,
+  indexedResolver,
+} from "@yornaath/batshit";
+
+import { profileSocialsQueryKey } from "./QueryKeys";
+import { queryClient } from "./queryClient";
+
+const profileSocials = create({
+  fetcher: async (addresses: string[]) => {
+    logger.info("Fetching profiles for addresses", addresses);
+    const data = await getProfilesForAddresses(addresses);
+    return data;
+  },
+  resolver: indexedResolver(),
+  scheduler: windowedFiniteBatchScheduler({
+    windowMs: 10,
+    maxBatchSize: 150,
+  }),
+});
+
+const fetchProfileSocials = async (peerAddress: string) => {
+  const data = await profileSocials.fetch(peerAddress);
+  // Save to mmkv to access it later
+  return data;
+};
+
+const profileSocialesQueryConfig = (account: string, peerAddress: string) => ({
+  queryKey: profileSocialsQueryKey(account, peerAddress),
+  queryFn: () => fetchProfileSocials(peerAddress),
+  enabled: !!account,
+  // Store for 30 days
+  gcTime: 1000 * 60 * 60 * 24 * 30,
+  refetchIntervalInBackground: false,
+  refetchOnWindowFocus: false,
+  // TODO: Clean this up after development
+  // refetchOnMount: false,
+  // We really just want a 24 hour cache here
+  // And automatic retries if there was an error fetching
+  staleTime: 1000, //1000 * 60 * 60 * 24,
+});
+
+export const useProfileSocialsQuery = (
+  account: string,
+  peerAddress: string
+) => {
+  return useQuery(profileSocialesQueryConfig(account, peerAddress));
+};
+
+export const useProfileSocialsQueries = (
+  account: string,
+  peerAddresses: string[]
+) => {
+  return useQueries({
+    queries: peerAddresses.map((peerAddress) =>
+      profileSocialesQueryConfig(account, peerAddress)
+    ),
+  });
+};
+
+export const fetchProfileSocialsQuery = (
+  account: string,
+  peerAddress: string
+) => {
+  return queryClient.fetchQuery(
+    profileSocialesQueryConfig(account, peerAddress)
+  );
+};
+
+export const setProfileSocialsQueryData = (
+  account: string,
+  peerAddress: string,
+  data: ProfileSocials,
+  updatedAt?: number
+) => {
+  return queryClient.setQueryData(
+    profileSocialsQueryKey(account, peerAddress),
+    data,
+    {
+      updatedAt,
+    }
+  );
+};

--- a/queries/useProfileSocialsQuery.ts
+++ b/queries/useProfileSocialsQuery.ts
@@ -1,7 +1,6 @@
 import { ProfileSocials } from "@data/store/profilesStore";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { getProfilesForAddresses } from "@utils/api";
-import logger from "@utils/logger";
 import {
   create,
   windowedFiniteBatchScheduler,
@@ -13,7 +12,6 @@ import { queryClient } from "./queryClient";
 
 const profileSocials = create({
   fetcher: async (addresses: string[]) => {
-    logger.info("Fetching profiles for addresses", addresses);
     const data = await getProfilesForAddresses(addresses);
     return data;
   },
@@ -26,7 +24,6 @@ const profileSocials = create({
 
 const fetchProfileSocials = async (peerAddress: string) => {
   const data = await profileSocials.fetch(peerAddress);
-  // Save to mmkv to access it later
   return data;
 };
 
@@ -38,11 +35,10 @@ const profileSocialesQueryConfig = (account: string, peerAddress: string) => ({
   gcTime: 1000 * 60 * 60 * 24 * 30,
   refetchIntervalInBackground: false,
   refetchOnWindowFocus: false,
-  // TODO: Clean this up after development
-  // refetchOnMount: false,
   // We really just want a 24 hour cache here
   // And automatic retries if there was an error fetching
-  staleTime: 1000, //1000 * 60 * 60 * 24,
+  refetchOnMount: false,
+  staleTime: 1000 * 60 * 60 * 24,
 });
 
 export const useProfileSocialsQuery = (

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -1,4 +1,5 @@
 import Picto from "@components/Picto/Picto";
+import { ConnectedAvatar } from "@containers/ConnectedAvatar";
 import { useDisconnectActionSheet } from "@hooks/useDisconnectActionSheet";
 import { useShouldShowErrored } from "@hooks/useShouldShowErrored";
 import { translate } from "@i18n";
@@ -43,7 +44,6 @@ import { ConversationNavParams } from "./Navigation/ConversationNav";
 import { NavigationParamList } from "./Navigation/Navigation";
 import { useIsSplitScreen } from "./Navigation/navHelpers";
 import ActivityIndicator from "../components/ActivityIndicator/ActivityIndicator";
-import Avatar from "../components/Avatar";
 import { showActionSheetWithOptions } from "../components/StateHandlers/ActionSheetStateHandler";
 import TableView, {
   TableViewItemType,
@@ -78,7 +78,6 @@ import {
   requestPushNotificationsPermissions,
 } from "../utils/notifications";
 import {
-  getPreferredAvatar,
   getPreferredName,
   getProfile,
   getPreferredUsername,
@@ -600,11 +599,7 @@ export default function ProfileScreen({
       style={styles.profile}
       contentContainerStyle={styles.profileContent}
     >
-      <Avatar
-        uri={getPreferredAvatar(socials)}
-        style={styles.avatar}
-        name={getPreferredName(socials, peerAddress)}
-      />
+      <ConnectedAvatar peerAddress={peerAddress} style={styles.avatar} />
       <Text style={styles.title}>{getPreferredName(socials, peerAddress)}</Text>
       {isMyProfile && shouldShowError && (
         <View style={styles.errorContainer}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9647,6 +9647,18 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
+"@yornaath/batshit-devtools@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@yornaath/batshit-devtools/-/batshit-devtools-1.7.1.tgz#6c247f2c4c4e3322811beca96cb62bbf19489e04"
+  integrity sha512-AyttV1Njj5ug+XqEWY1smV45dTWMlWKtj1B8jcFYgBKUFyUlF/qEhD+iP1E5UaRYW6hQRYD9T2WNDwFTrOMWzQ==
+
+"@yornaath/batshit@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@yornaath/batshit/-/batshit-0.10.1.tgz#f750b2bf6abb9207330eb6a5ab2356af9b79ae78"
+  integrity sha512-WGZ1WNoiVN6CLf28O73+6SCf+2lUn4U7TLGM9f4zOad0pn9mdoXIq8cwu3Kpf7N2OTYgWGK4eQPTflwFlduDGA==
+  dependencies:
+    "@yornaath/batshit-devtools" "^1.7.1"
+
 "@zxing/text-encoding@0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"


### PR DESCRIPTION
Why?
Right now zustand is being used to manage the network state of profiles We refresh profiles whenever a new group is added/new conversation/group is refreshed

Theres some potential issues:
Groups can get large
Conversation lists can get large
New and interesting ways of using profiles in the app may be added (group invites for example) These require adding additional checks if we should update the profiles etc. What happens when a request fails? What happens if members change? As we move towards open source it can be helpful to devs to have more consumable hooks, rather than tracking down exactly where the data is coming from and why it's refreshing/cached/missing

With React Query we get better out of the box retries, and can use a batching and deduplicating library to manage this for us The main goal of this is that incase anything gets missed, we can have a foolproof fallback to refresh just in case

We can further improve the usage of profiles by:
1. Having MMKV entries for each profile rather than the whole state
2. Remove fetching in group syncs and have a full fetch for each groups members later on
3. Completely removing the Zustand profile store to avoid storing network state in Zustand

Closes https://github.com/ephemeraHQ/converse-app/issues/583 


