### PR TITLE
Improve list conversation performance

### DIFF
--- a/utils/set.test.ts
+++ b/utils/set.test.ts
@@ -1,0 +1,49 @@
+import { areSetsEqual } from "./set"; // Replace with the actual file path
+
+describe("areSetsEqual", () => {
+  test("returns true for two empty sets", () => {
+    const setA = new Set();
+    const setB = new Set();
+    expect(areSetsEqual(setA, setB)).toBe(true);
+  });
+
+  test("returns true for sets with the same elements", () => {
+    const setA = new Set([1, 2, 3]);
+    const setB = new Set([3, 2, 1]);
+    expect(areSetsEqual(setA, setB)).toBe(true);
+  });
+
+  test("returns false for sets with different elements", () => {
+    const setA = new Set([1, 2, 3]);
+    const setB = new Set([4, 5, 6]);
+    expect(areSetsEqual(setA, setB)).toBe(false);
+  });
+
+  test("returns false for sets of different sizes", () => {
+    const setA = new Set([1, 2]);
+    const setB = new Set([1, 2, 3]);
+    expect(areSetsEqual(setA, setB)).toBe(false);
+  });
+
+  test("returns false for sets with the same size but different elements", () => {
+    const setA = new Set([1, 2, 3]);
+    const setB = new Set([1, 2, 4]);
+    expect(areSetsEqual(setA, setB)).toBe(false);
+  });
+
+  test("returns true for sets with the same elements of different types", () => {
+    const setA = new Set(["1", "2", "3"]);
+    const setB = new Set(["3", "2", "1"]);
+    expect(areSetsEqual(setA, setB)).toBe(true);
+  });
+
+  test("returns true for sets with complex elements", () => {
+    const obj1 = { key: "value" };
+    const obj2 = { key: "value" };
+    const setA = new Set([obj1]);
+    const setB = new Set([obj1]);
+    const setC = new Set([obj2]); // Different reference
+    expect(areSetsEqual(setA, setB)).toBe(true);
+    expect(areSetsEqual(setA, setC)).toBe(false);
+  });
+});

--- a/utils/set.ts
+++ b/utils/set.ts
@@ -1,0 +1,9 @@
+// Helper function to compare two sets
+export const areSetsEqual = (
+  setA: Set<unknown>,
+  setB: Set<unknown>
+): boolean => {
+  if (setA.size !== setB.size) return false;
+  for (const a of setA) if (!setB.has(a)) return false;
+  return true;
+};

--- a/utils/xmtpRN/conversations.ts
+++ b/utils/xmtpRN/conversations.ts
@@ -689,9 +689,12 @@ const importBackedTopicsData = async (client: ConverseXmtpClientType) => {
       const importedConversations = await Promise.all(
         topicsData.map((data) => client.conversations.importTopicData(data))
       );
-      importedConversations.forEach((conversation) => {
-        setOpenedConversation(client.address, conversation);
-      });
+
+      const setOpenedPromises = importedConversations.map((conversation) =>
+        setOpenedConversation(client.address, conversation)
+      );
+      await Promise.all(setOpenedPromises);
+
       const afterImport = new Date().getTime();
       logger.debug(
         `[XmtpRN] Imported ${

--- a/utils/xmtpRN/conversations.ts
+++ b/utils/xmtpRN/conversations.ts
@@ -2,10 +2,10 @@ import { entifyWithAddress } from "@queries/entify";
 import { setGroupDescriptionQueryData } from "@queries/useGroupDescriptionQuery";
 import { setGroupMembersQueryData } from "@queries/useGroupMembersQuery";
 import { setGroupQueryData } from "@queries/useGroupQuery";
-import { arraysContainSameElements } from "@utils/array";
 import { converseEventEmitter } from "@utils/events";
 import { getGroupIdFromTopic } from "@utils/groupUtils/groupId";
 import logger from "@utils/logger";
+import { areSetsEqual } from "@utils/set";
 import {
   ConsentListEntry,
   ConversationContext,
@@ -312,13 +312,6 @@ const listGroups = async (client: ConverseXmtpClientType) => {
 
 export const importedTopicsDataForAccount: { [account: string]: boolean } = {};
 
-// Helper function to compare two sets
-function areSetsEqual(setA: Set<any>, setB: Set<any>): boolean {
-  if (setA.size !== setB.size) return false;
-  for (const a of setA) if (!setB.has(a)) return false;
-  return true;
-}
-
 export const loadConversations = async (
   account: string,
   knownTopics: string[]
@@ -356,8 +349,10 @@ export const loadConversations = async (
         newGroups.push(g);
       } else {
         knownGroups.push(g);
-        const existingGroup = getChatStore(account).getState().conversations[g.topic] as XmtpGroupConversation;
-        
+        const existingGroup = getChatStore(account).getState().conversations[
+          g.topic
+        ] as XmtpGroupConversation;
+
         if (!existingGroup) {
           updatedGroups.push(g);
         } else {
@@ -699,10 +694,9 @@ const importBackedTopicsData = async (client: ConverseXmtpClientType) => {
         topicsData.map((data) => client.conversations.importTopicData(data))
       );
 
-      const setOpenedPromises = importedConversations.map((conversation) =>
-        setOpenedConversation(client.address, conversation)
-      );
-      await Promise.all(setOpenedPromises);
+      importedConversations.forEach((conversation) => {
+        setOpenedConversation(client.address, conversation);
+      });
 
       const afterImport = new Date().getTime();
       logger.debug(


### PR DESCRIPTION
We're seeing the app freeze frequently for users. On export it appears there is some performance issues with importing and listing conversations

Some stats

> 1:51:21 PM | DEBUG : [XmtpRN] Imported 846 exported conversations into client in 66.073s
> 1:51:36 PM | DEBUG : [XmtpRN] Listing 0 conversations for 0x2659aBe3F33c3BA20B9F440f24b746A22b1d53F7 took 14.756 seconds
> 1:51:37 PM | DEBUG : [XmtpRN] Listing 846 conversations for 0xf0EA7663233F99D0c12370671abBb6Cca980a490 took 81.935 seconds

This parallelizes some stuff during import and converts known topics to a set to help with performance.

The SDK lists 2k conversations in ~ 10s so 14 seconds to load 0 conversations looks like potentially an issue in this code somewhere.
