### PR TITLE
fix: image preview opening on long press

### DIFF
--- a/components/Chat/Attachment/AttachmentMessagePreview.tsx
+++ b/components/Chat/Attachment/AttachmentMessagePreview.tsx
@@ -166,7 +166,7 @@ const useStyles = () => {
   const colorScheme = useColorScheme();
   return StyleSheet.create({
     imagePreview: {
-      borderRadius: 14,
+      borderRadius: 18,
       width: "100%",
       zIndex: 1,
       minWidth: Platform.OS === "web" ? 250 : undefined,


### PR DESCRIPTION
This fixes the issue where frequently (but not always) long-pressing an image will both bring up the context menu and the preview.

I figured this might involve GestureDetector and ReanimatedTouchableOpacity onPress both firing, so moved the latter into a tap gesture. Tested this with an on-device development build and seems to fix the issue.