### PR TITLE
feat: use ephemeral account for deniability

### DIFF
--- a/components/AccountSettingsButton.tsx
+++ b/components/AccountSettingsButton.tsx
@@ -1,3 +1,4 @@
+import { useDisconnectActionSheet } from "@hooks/useDisconnectActionSheet";
 import { translate } from "@i18n";
 import Clipboard from "@react-native-clipboard/clipboard";
 import { NavigationProp } from "@react-navigation/native";
@@ -28,7 +29,6 @@ import {
 import { useAppStore } from "../data/store/appStore";
 import { useSelect } from "../data/store/storeHelpers";
 import { converseEventEmitter } from "../utils/events";
-import { useLogoutFromConverse } from "../utils/logout";
 import { navigate } from "../utils/navigation";
 import {
   NotificationPermissionStatus,
@@ -57,40 +57,8 @@ export default function AccountSettingsButton({ account, navigation }: Props) {
     useSelect(["setCurrentAccount"])
   );
   const erroredAccountsMap = useErroredAccountsMap();
-  const logout = useLogoutFromConverse(account);
   const colorScheme = useColorScheme();
-
-  const showDeleteAccountActionSheet = useCallback(async () => {
-    if (Platform.OS === "web") {
-      // Fixes double action sheet on web
-      await new Promise((r) => setTimeout(r, 100));
-    }
-    const methods = {
-      [translate("disconnect")]: () => logout(false),
-      [translate("disconnect_delete_group_chats")]: () => logout(true),
-      [translate("cancel")]: () => {},
-    };
-
-    const options = Object.keys(methods);
-
-    showActionSheetWithOptions(
-      {
-        options,
-        title: translate("disconnect_this_account"),
-        message: translate("disconnect_account_description"),
-        cancelButtonIndex: options.indexOf(translate("cancel")),
-        destructiveButtonIndex: [1],
-        ...actionSheetColors(colorScheme),
-      },
-      (selectedIndex?: number) => {
-        if (selectedIndex === undefined) return;
-        const method = (methods as any)[options[selectedIndex]];
-        if (method) {
-          method();
-        }
-      }
-    );
-  }, [colorScheme, logout]);
+  const showDisconnectActionSheet = useDisconnectActionSheet();
 
   const onPress = useCallback(() => {
     Keyboard.dismiss();
@@ -143,9 +111,8 @@ export default function AccountSettingsButton({ account, navigation }: Props) {
           );
         }
       },
-      [translate("disconnect_this_account")]: () => {
-        showDeleteAccountActionSheet();
-      },
+      [translate("disconnect_this_account")]: () =>
+        showDisconnectActionSheet(colorScheme),
       [translate("cancel")]: () => {},
     };
 
@@ -196,7 +163,7 @@ export default function AccountSettingsButton({ account, navigation }: Props) {
     setCurrentAccount,
     navigation,
     setNotificationsPermissionStatus,
-    showDeleteAccountActionSheet,
+    showDisconnectActionSheet,
   ]);
 
   return Platform.OS === "android" ? (

--- a/components/EphemeralAccountBanner.tsx
+++ b/components/EphemeralAccountBanner.tsx
@@ -1,3 +1,4 @@
+import { useDisconnectActionSheet } from "@hooks/useDisconnectActionSheet";
 import {
   itemSeparatorColor,
   messageBubbleColor,
@@ -8,29 +9,35 @@ import React, {
   Platform,
   StyleSheet,
   Text,
+  TouchableOpacity,
   useColorScheme,
   View,
 } from "react-native";
 
 export default function EphemeralAccountBanner() {
   const styles = useStyles();
+  const colorScheme = useColorScheme();
+  const showDisconnectActionSheet = useDisconnectActionSheet();
   return (
-    <View style={styles.demoAccountBanner}>
-      <View style={styles.demoAccountBannerLeft}>
-        <Text style={styles.demoAccountTitle}>This account is ephemeral</Text>
-        <Text style={styles.demoAccountSubtitle} numberOfLines={4}>
-          If you log out, you’ll lose all of your conversations. Log in with an
-          existing wallet when you’re ready.
+    <TouchableOpacity
+      onPress={() => showDisconnectActionSheet(colorScheme)}
+      style={styles.tempAccountBanner}
+    >
+      <View style={styles.tempAccountBannerLeft}>
+        <Text style={styles.tempAccountTitle}>This account is ephemeral</Text>
+        <Text style={styles.tempAccountSubtitle} numberOfLines={4}>
+          Disconnect to permanently remove your device from these conversations
+          and ensure deniability.
         </Text>
       </View>
-    </View>
+    </TouchableOpacity>
   );
 }
 
 const useStyles = () => {
   const colorScheme = useColorScheme();
   return StyleSheet.create({
-    demoAccountBanner: {
+    tempAccountBanner: {
       width: "100%",
       borderBottomColor: itemSeparatorColor(colorScheme),
       backgroundColor: messageBubbleColor(colorScheme),
@@ -41,7 +48,6 @@ const useStyles = () => {
       zIndex: 1000,
       ...Platform.select({
         default: {
-          marginTop: 12,
           marginBottom: 8,
           paddingVertical: 12,
           paddingLeft: 30,
@@ -49,11 +55,11 @@ const useStyles = () => {
         android: { paddingVertical: 14, paddingLeft: 16 },
       }),
     },
-    demoAccountBannerLeft: {
+    tempAccountBannerLeft: {
       flexShrink: 1,
       marginRight: 10,
     },
-    demoAccountTitle: {
+    tempAccountTitle: {
       color: textPrimaryColor(colorScheme),
       ...Platform.select({
         default: {
@@ -65,7 +71,7 @@ const useStyles = () => {
         },
       }),
     },
-    demoAccountSubtitle: {
+    tempAccountSubtitle: {
       fontSize: Platform.OS === "android" ? 14 : 15,
       color: textSecondaryColor(colorScheme),
       fontWeight: "400",

--- a/hooks/useDisconnectActionSheet.ts
+++ b/hooks/useDisconnectActionSheet.ts
@@ -55,9 +55,3 @@ export const useDisconnectActionSheet = () => {
     [logout, ephemeralAccount]
   );
 };
-
-export const showDeleteAccountActionSheet = async (
-  colorScheme: ColorSchemeName,
-  logout: (deleteLocalChats: boolean) => void,
-  ephemeralAccount: boolean
-) => {};

--- a/hooks/useDisconnectActionSheet.ts
+++ b/hooks/useDisconnectActionSheet.ts
@@ -1,0 +1,63 @@
+import { translate } from "@i18n";
+import { actionSheetColors } from "@styles/colors";
+import { useCallback } from "react";
+import { ColorSchemeName, Platform } from "react-native";
+
+import { showActionSheetWithOptions } from "../components/StateHandlers/ActionSheetStateHandler";
+import {
+  useSettingsStore,
+  useAccountsStore,
+} from "../data/store/accountsStore";
+import { useLogoutFromConverse } from "../utils/logout";
+
+export const useDisconnectActionSheet = () => {
+  const account = useAccountsStore((s) => s.currentAccount);
+  const logout = useLogoutFromConverse(account);
+  const { ephemeralAccount } = useSettingsStore((s) => ({
+    ephemeralAccount: s.ephemeralAccount,
+  }));
+
+  return useCallback(
+    async (colorScheme: ColorSchemeName) => {
+      if (Platform.OS === "web") {
+        // Fixes double action sheet on web
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      const methods: Record<string, () => void> = {
+        [translate("disconnect_delete_local_data")]: () => logout(true),
+        [translate("cancel")]: () => {},
+      };
+      if (!ephemeralAccount) {
+        methods[translate("disconnect")] = () => logout(false);
+      }
+
+      const options = Object.keys(methods);
+      showActionSheetWithOptions(
+        {
+          options,
+          title: !ephemeralAccount ? translate("disconnect_this_account") : "",
+          message: !ephemeralAccount
+            ? translate("disconnect_account_description")
+            : "",
+          cancelButtonIndex: options.indexOf(translate("cancel")),
+          destructiveButtonIndex: [1],
+          ...actionSheetColors(colorScheme),
+        },
+        (selectedIndex?: number) => {
+          if (selectedIndex === undefined) return;
+          const method = (methods as any)[options[selectedIndex]];
+          if (method) {
+            method();
+          }
+        }
+      );
+    },
+    [logout, ephemeralAccount]
+  );
+};
+
+export const showDeleteAccountActionSheet = async (
+  colorScheme: ColorSchemeName,
+  logout: (deleteLocalChats: boolean) => void,
+  ephemeralAccount: boolean
+) => {};

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -64,7 +64,7 @@ const en = {
   camera: "Camera",
 
   disconnect: "Disconnect",
-  disconnect_delete_group_chats: "Disconnect and delete group chats",
+  disconnect_delete_local_data: "Disconnect and delete local data",
   disconnect_this_account: "Disconnect this account",
   disconnect_account_description:
     "Your group chats will be encrypted and saved on your device until you delete Converse. Your DMs will be backed up by the XMTP network.",

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -1,4 +1,5 @@
 import Picto from "@components/Picto/Picto";
+import { useDisconnectActionSheet } from "@hooks/useDisconnectActionSheet";
 import { useShouldShowErrored } from "@hooks/useShouldShowErrored";
 import { translate } from "@i18n";
 import Clipboard from "@react-native-clipboard/clipboard";
@@ -61,7 +62,6 @@ import {
   getAddressIsAdmin,
   getAddressIsSuperAdmin,
 } from "../utils/groupUtils/adminUtils";
-import { useLogoutFromConverse } from "../utils/logout";
 import { navigate } from "../utils/navigation";
 import {
   NotificationPermissionStatus,
@@ -188,7 +188,7 @@ export default function ProfileScreen({
   ];
 
   const isPrivy = useLoggedWithPrivy();
-  const logout = useLogoutFromConverse(userAddress);
+  const showDisconnectActionSheet = useDisconnectActionSheet();
 
   const getSocialItemsFromArray = useCallback(
     <T,>(
@@ -296,39 +296,6 @@ export default function ProfileScreen({
       ),
     });
   }
-
-  const showDeleteAccountActionSheet = useCallback(async () => {
-    if (Platform.OS === "web") {
-      // Fixes double action sheet on web
-      await new Promise((r) => setTimeout(r, 100));
-    }
-    const methods = {
-      Disconnect: () => logout(false),
-      "Disconnect and delete group chats": () => logout(true),
-      Cancel: () => {},
-    };
-
-    const options = Object.keys(methods);
-
-    showActionSheetWithOptions(
-      {
-        options,
-        title: "Disconnect this account",
-        message:
-          "Your group chats will be encrypted and saved on your device until you delete Converse. Your DMs will be backed up by the XMTP network.",
-        cancelButtonIndex: options.indexOf("Cancel"),
-        destructiveButtonIndex: [1],
-        ...actionSheetColors(colorScheme),
-      },
-      (selectedIndex?: number) => {
-        if (selectedIndex === undefined) return;
-        const method = (methods as any)[options[selectedIndex]];
-        if (method) {
-          method();
-        }
-      }
-    );
-  }, [colorScheme, logout]);
 
   const actionsTableViewItems = useMemo(() => {
     const items: TableViewItemType[] = [];
@@ -796,7 +763,7 @@ export default function ProfileScreen({
                     : dangerColor(colorScheme),
                 action: () => {
                   setTimeout(() => {
-                    showDeleteAccountActionSheet();
+                    showDisconnectActionSheet(colorScheme);
                   }, 300);
                 },
               },


### PR DESCRIPTION
- Updates copy of ephemeral account banner to reflect deniability value prop: _"Disconnect to permanently remove your device from these conversations and ensure deniability."_
- Tap banner to logout and delete
- Only allow disconnect without delete if account is not ephemeral