### PR TITLE
Noe/more timing logs for perf

### DIFF
--- a/queries/useGroupsQuery.ts
+++ b/queries/useGroupsQuery.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import logger from "@utils/logger";
 import { getXmtpClient } from "@utils/xmtpRN/sync";
 
 import { groupsQueryKey } from "./QueryKeys";
@@ -19,8 +20,19 @@ const groupsQueryFn = async (account: string) => {
       ids: [],
     };
   }
+  const beforeSync = new Date().getTime();
   await client.conversations.syncGroups();
+  const afterSync = new Date().getTime();
+  logger.debug(
+    `[Groups] Fetching group list took ${(afterSync - beforeSync) / 1000} sec`
+  );
   const groups = await client.conversations.listGroups();
+  const afterList = new Date().getTime();
+  logger.debug(
+    `[Groups] Listing ${groups.length} groups took ${
+      (afterList - afterSync) / 1000
+    } sec`
+  );
   return entify(groups, (group) => group.topic);
 };
 

--- a/utils/xmtpRN/conversations.ts
+++ b/utils/xmtpRN/conversations.ts
@@ -653,8 +653,14 @@ export const refreshGroup = async (account: string, topic: string) => {
 
 export const loadConversationsHmacKeys = async (account: string) => {
   const client = (await getXmtpClient(account)) as ConverseXmtpClientType;
-
+  const before = new Date().getTime();
   const { hmacKeys } = await client.conversations.getHmacKeys();
+  const after = new Date().getTime();
+  logger.debug(
+    `[XmtpRn] Fetched ${Object.keys(hmacKeys).length} hmac keys in ${
+      (after - before) / 1000
+    } sec`
+  );
   return hmacKeys;
 };
 

--- a/utils/xmtpRN/conversations.ts
+++ b/utils/xmtpRN/conversations.ts
@@ -301,7 +301,14 @@ const listGroups = async (client: ConverseXmtpClientType) => {
   // @todo => this will be adapted once we have a syncAllGroups method
   await fetchGroupsQuery(client.address);
   // Resync process
+  const beforeSyncAll = new Date().getTime();
   await client.conversations.syncAllGroups();
+  const afterSyncAll = new Date().getTime();
+  logger.debug(
+    `[Groups] Syncing all groups took ${
+      (afterSyncAll - beforeSyncAll) / 1000
+    } sec`
+  );
   // Now that it's synced, let's refresh
   const updatedGroups = await fetchGroupsQuery(client.address, 0);
   return updatedGroups.ids.map((id) => {

--- a/utils/xmtpRN/conversations.ts
+++ b/utils/xmtpRN/conversations.ts
@@ -420,8 +420,19 @@ export const loadConversations = async (
 export const updateConsentStatus = async (account: string) => {
   try {
     const client = (await getXmtpClient(account)) as ConverseXmtpClientType;
+    const beforeFetch = new Date().getTime();
     const consentList = await client.contacts.refreshConsentList();
+    const afterFetch = new Date().getTime();
+    logger.debug(
+      `[Consent] Fetched consent state in ${
+        (afterFetch - beforeFetch) / 1000
+      } sec`
+    );
     await saveConsentState(consentList, client.address);
+    const afterSave = new Date().getTime();
+    logger.debug(
+      `[Consent] SAved consent state in ${(afterSave - afterFetch) / 1000} sec`
+    );
   } catch (error) {
     logger.error(error, { context: "Failed to update consent status:" });
   }
@@ -692,8 +703,14 @@ const retrieveTopicsData = async (
 
 const importBackedTopicsData = async (client: ConverseXmtpClientType) => {
   try {
-    const beforeImport = new Date().getTime();
+    const beforeRetrieve = new Date().getTime();
     const topicsData = Object.values(await retrieveTopicsData(client.address));
+    const beforeImport = new Date().getTime();
+    logger.debug(
+      `[XmtpRN] Retrieved ${topicsData.length} topic data from mmkv in ${
+        (beforeImport - beforeRetrieve) / 1000
+      } sec`
+    );
     // If we have topics for this account, let's import them
     // so the first conversation.list() is faster
     if (topicsData.length > 0) {

--- a/utils/xmtpRN/sync.ts
+++ b/utils/xmtpRN/sync.ts
@@ -152,7 +152,6 @@ export const syncXmtpClient = async (account: string) => {
   });
   try {
     const now = new Date().getTime();
-    updateConsentStatus(account);
     const { newConversations, groups, newGroups } = await loadConversations(
       account,
       knownTopics
@@ -208,6 +207,7 @@ export const syncXmtpClient = async (account: string) => {
         ]);
     }
     currentBackoff = INITIAL_BACKOFF;
+    await updateConsentStatus(account);
     logger.info(`[XmtpRN] Finished syncing ${account}`);
   } catch (e) {
     onSyncLost(account, e);


### PR DESCRIPTION
Added more timing logs to debug perf / freeze on load
Also moved the consent fetching at the end of the sync process, and using `await` since it was the only thing that was running in parallel of other stuff during the sync process which might have caused the freeze that seems to come from importing topic data