### PR TITLE
Perf MMKV: Avoid multiple writes to same key, use different instances zustand / react-query

### DIFF
--- a/utils/mmkv.ts
+++ b/utils/mmkv.ts
@@ -12,6 +12,9 @@ export default storage;
 
 export const zustandMMKVStorage: StateStorage = {
   setItem: (name, value) => {
+    // Deleting before setting to avoid memory leak
+    // https://github.com/mrousavy/react-native-mmkv/issues/440
+    storage.delete(name);
     return storage.set(name, value);
   },
   getItem: (name) => {
@@ -47,17 +50,22 @@ export const clearSecureMmkvForAccount = async (account: string) => {
   delete secureMmkvByAccount[account];
 };
 
+const reactQueryPersister = new MMKV({ id: "converse-react-query" });
+
 export const mmkvStoragePersister = createSyncStoragePersister({
   storage: {
     setItem: (key, value) => {
-      storage.set(key, value);
+      // Deleting before setting to avoid memory leak
+      // https://github.com/mrousavy/react-native-mmkv/issues/440
+      reactQueryPersister.delete(key);
+      reactQueryPersister.set(key, value);
     },
     getItem: (key) => {
-      const value = storage.getString(key);
+      const value = reactQueryPersister.getString(key);
       return value === undefined ? null : value;
     },
     removeItem: (key) => {
-      storage.delete(key);
+      reactQueryPersister.delete(key);
     },
   },
   serialize: stringify,


### PR DESCRIPTION
I was happy because I was having the "freeze on load" issue on my dev app
However I applied a stashed diff that was adding logs and **disabling the mmkv cache for react-query** and it went through without freezing anymore

So I deep dived on what could cause MMKV to freeze the app and found out this thread about memory leaks:
https://github.com/mrousavy/react-native-mmkv/issues/440

Basically, when you `mmkv.set("a", "test")` then again `mmkv.set("a", "test-2")`, by default, MMKV does not replace the first entry (this is by design, to be faster)
This makes the file grow kind of uncontrollably (by checking the thread and some chinese comments on the MMKV repo it seems at some point it should still pack the file but maybe it's getting too big too fast)

Another indicator that this might be the issue is that when I returned an empty view from ConversationList it wasn't freezing anymore, showing that this could be linked to the heavy use of react query inside this component

However I'm not 100% sure, just trying the solution from the thread to see if it fixes our freeze issue

I also decided to give react-query a dedicated mmkv instance