### PR TITLE
Disable structural sharing

### DIFF
--- a/queries/queryClient.ts
+++ b/queries/queryClient.ts
@@ -5,6 +5,7 @@ export const queryClient = new QueryClient({
     queries: {
       gcTime: 1000 * 60 * 60 * 24, // 24 hours
       staleTime: 1000 * 60 * 60, // 1 hour
+      structuralSharing: false,
     },
   },
 });


### PR DESCRIPTION
Kept digging on the app that freezes sometimes
From my latest PR : https://github.com/ephemeraHQ/converse-app/pull/656 I knew that the MMKV storage (for react-query) had smth to do with it. This has been confirmed in DEV, enabling / disabling the persistence for react-query causes / removes the freeze.

This PR disables `structuralSharing`
From the [react-query docs](https://tanstack.com/query/latest/docs/framework/react/guides/important-defaults#important-defaults), structuralSharing aims to improve perf, but

> If you are seeing performance issues because of large responses for example, you can disable this feature with the config.structuralSharing flag

I can confirm that on my failing dev env, this fixes the issue. However I don't know for how long!

Thoughts, cc @alexrisch 

- by adding logs, I actually see that every time the react-query cache needs to be persisted (i.e. after each query!), the *WHOLE* react-query state (i.e. for all queries) is JSON-encoded and persisted in a SINGLE mmkv key (`REACT_QUERY_OFFLINE_CACHE`). I thought that there would be an mmkv entry for each query key! This is def subperformant because the whole cache can get quite big and serialization / deserialization is CPU intensive, blocking the JS thread
- I think this is the way react-query works and maybe we can't change it
- if we still have issues, we could try playing with settings
- if we still have issues, we could also try AsyncStorage (since it's async maybe it will block less the JS thread)
- if we still have issues, we could also disable the react-query cache (how impactful would that be @alexrisch ?)

