### PR TITLE
fix: message spacing for last in series not from me

### DIFF
--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -248,7 +248,10 @@ function ChatMessage({ message, colorScheme, isGroup, isFrame }: Props) {
       style={[
         styles.messageRow,
         {
-          marginBottom: showStatus ? 8 : 1,
+          marginBottom:
+            showStatus || (!message.fromMe && !message.hasNextMessageInSeries)
+              ? 8
+              : 1,
         },
       ]}
     >


### PR DESCRIPTION
Adds a little spacing below the last message bubble in a series not from me

<img src="https://github.com/user-attachments/assets/b5f4a83d-de4f-4441-b0ac-d9cb7ede43af" width =350/><img src="https://github.com/user-attachments/assets/4e57c974-2b0f-4254-a771-e76e1ad99e76" width=350/>
