### PR TITLE
fix: side margins around messages

### DIFF
--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -532,7 +532,8 @@ const useStyles = () => {
     messageSwipeable: {
       width: "100%",
       flexDirection: "row",
-      paddingHorizontal: 10,
+      paddingLeft: 12,
+      paddingRight: 15,
       overflow: "visible",
     },
     messageSwipeableChildren: {


### PR DESCRIPTION
Adds a little breathing room on the sides by increasing message padding to match iMessage.