### PR TITLE
Encrypt the converse database, including migrating an existing one

### DIFF
--- a/data/db/driver.ts
+++ b/data/db/driver.ts
@@ -90,12 +90,11 @@ export const typeORMDriver = (
       const initialDbPath = options.location
         ? path.join(options.location, options.name)
         : options.name;
-      // First check if we can open it without an encryption key
       let db = open(options);
       db.execute(`PRAGMA cipher_plaintext_header_size = 32;`);
       db.execute(`PRAGMA cipher_salt = "x'${encryptionSalt}'";`);
       try {
-        // Try to execute a query with an encryption key
+        // Try to execute a query with the encryption key
         db.execute("SELECT name FROM sqlite_master WHERE type='table';");
       } catch (e: any) {
         logger.warn(

--- a/data/store/accountsStore.ts
+++ b/data/store/accountsStore.ts
@@ -96,6 +96,7 @@ type AccountsStoreStype = {
   accounts: string[];
   removeAccount: (account: string) => void;
   databaseId: { [account: string]: string };
+  setDatabaseId: (account: string, id: string) => void;
   resetDatabaseId: (account: string) => void;
   privyAccountId: { [account: string]: string | undefined };
   setPrivyAccountId: (account: string, id: string | undefined) => void;
@@ -114,6 +115,12 @@ export const useAccountsStore = create<AccountsStoreStype>()(
           return { privyAccountId };
         }),
       databaseId: {},
+      setDatabaseId: (account, id) =>
+        set((state) => {
+          const databaseId = { ...state.databaseId };
+          databaseId[account] = id;
+          return { databaseId };
+        }),
       resetDatabaseId: (account) =>
         set((state) => {
           const databaseId = { ...state.databaseId };

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -398,6 +398,7 @@ PODS:
     - MMKVCore (~> 1.3.3)
   - MMKVCore (1.3.3)
   - op-sqlite (6.0.1):
+    - OpenSSL-Universal
     - React
     - React-callinvoker
     - React-Core
@@ -2321,7 +2322,7 @@ SPEC CHECKSUMS:
   MMKV: f902fb6719da13c2ab0965233d8963a59416f911
   MMKVAppExtension: fcf23c6b250cc87db63507bc57be8e6ed378168d
   MMKVCore: d26e4d3edd5cb8588c2569222cbd8be4231374e9
-  op-sqlite: 1ca30186b8d062cd451f1d999c691caf151d13e2
+  op-sqlite: 7720c6cc59e76c983263edc07420e642b45fa288
   OpenSSL-Universal: 6e1ae0555546e604dbc632a2b9a24a9c46c41ef6
   RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
   RCTDeprecation: 3afceddffa65aee666dafd6f0116f1d975db1584
@@ -2417,7 +2418,7 @@ SPEC CHECKSUMS:
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
   XMTP: a9e7382ec5b57eeda3df7b177f034d061e3c9b61
   XMTPReactNative: 63c46d6ba9b8dc5831ea49e8716f4b60cc012651
-  Yoga: 33622183a85805e12703cd618b2c16bfd18bfffb
+  Yoga: 1ab23c1835475da69cf14e211a560e73aab24cb0
 
 PODFILE CHECKSUM: beb6a8b55061fc0f811288dc66c75239474eba01
 

--- a/package.json
+++ b/package.json
@@ -239,6 +239,9 @@
     "typescript": "^5.3.0",
     "warn-once": "^0.1.1"
   },
+  "op-sqlite": {
+    "sqlcipher": true
+  },
   "private": true,
   "lint-staged": {
     "*.{tsx,ts}": [

--- a/patches/@op-engineering+op-sqlite+6.0.1.patch
+++ b/patches/@op-engineering+op-sqlite+6.0.1.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/@op-engineering/op-sqlite/cpp/bindings.cpp b/node_modules/@op-engineering/op-sqlite/cpp/bindings.cpp
+index 792dbba..c3398b9 100644
+--- a/node_modules/@op-engineering/op-sqlite/cpp/bindings.cpp
++++ b/node_modules/@op-engineering/op-sqlite/cpp/bindings.cpp
+@@ -73,10 +73,10 @@ void install(jsi::Runtime &rt,
+     }
+ 
+ #ifdef OP_SQLITE_USE_SQLCIPHER
+-    if (encryptionKey.empty()) {
+-      throw std::runtime_error(
+-          "[OP SQLite] using SQLCipher encryption key is required");
+-    }
++//    if (encryptionKey.empty()) {
++//      throw std::runtime_error(
++//          "[OP SQLite] using SQLCipher encryption key is required");
++//    }
+ //      TODO(osp) find a way to display the yellow box from c++
+ #else
+     // if (!encryptionKey.empty()) {

--- a/utils/keychain/helpers.ts
+++ b/utils/keychain/helpers.ts
@@ -142,3 +142,14 @@ export const getDbEncryptionKey = async () => {
   );
   return new Uint8Array(newKey);
 };
+
+export const getDbEncryptionSalt = async () => {
+  const existingSalt = await getSecureItemAsync("CONVERSE_DB_ENCRYPTION_SALT");
+  if (existingSalt) {
+    return existingSalt.slice(0, 32);
+  }
+  const newKey = Buffer.from(await getRandomBytesAsync(16));
+  const newKeyHex = newKey.toString("hex");
+  await setSecureItemAsync("CONVERSE_DB_ENCRYPTION_SALT", newKeyHex);
+  return newKeyHex;
+};

--- a/utils/keychain/helpers.ts
+++ b/utils/keychain/helpers.ts
@@ -146,7 +146,7 @@ export const getDbEncryptionKey = async () => {
 export const getDbEncryptionSalt = async () => {
   const existingSalt = await getSecureItemAsync("CONVERSE_DB_ENCRYPTION_SALT");
   if (existingSalt) {
-    return existingSalt.slice(0, 32);
+    return existingSalt;
   }
   const newKey = Buffer.from(await getRandomBytesAsync(16));
   const newKeyHex = newKey.toString("hex");


### PR DESCRIPTION
Encrypting the converse database 

- generating a salt on device and saving it to keystore
- using that salt + db encryption key when we generate a database
- setup plaintext header of 32 bytes to avoid 0xdead10cc crashes on iOS
- detect an unencrypted database, and migration to encrypt it
- path op-sqlite to be able to handle encrypted database AND unencrypted databases to be able to do the migration