### PR TITLE
Reverting SDK update fixes file not database error on login

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -17,8 +17,8 @@ install! 'cocoapods',
 
 
 # Version must match version from XMTP Podspec (matching @xmtp/react-native-sdk from package.json)
-# https://github.com/xmtp/xmtp-react-native/blob/v2.5.4/ios/XMTPReactNative.podspec#L29
-$xmtpVersion = '0.14.13'
+# https://github.com/xmtp/xmtp-react-native/blob/v2.5.3/ios/XMTPReactNative.podspec#L29
+$xmtpVersion = '0.14.12'
 
 # Pinning MMKV to 1.3.3 that has included that fix https://github.com/Tencent/MMKV/pull/1222#issuecomment-1905164314
 $mmkvVersion = '1.3.3'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - SwiftProtobuf (~> 1.25.2)
   - ContextMenuAuxiliaryPreview (0.4.0):
     - DGSwiftUtilities (~> 0.13)
-  - DGSwiftUtilities (0.28.0)
+  - DGSwiftUtilities (0.29.0)
   - DoubleConversion (1.1.6)
   - EASClient (0.12.0):
     - ExpoModulesCore
@@ -389,7 +389,7 @@ PODS:
   - libwebp/sharpyuv (1.3.2)
   - libwebp/webp (1.3.2):
     - libwebp/sharpyuv
-  - LibXMTP (0.5.8-beta5)
+  - LibXMTP (0.5.8-beta4)
   - Logging (1.0.0)
   - MessagePacker (0.4.7)
   - MMKV (1.3.3):
@@ -1815,16 +1815,16 @@ PODS:
     - GenericJSON (~> 2.0)
     - Logging (~> 1.0.0)
     - secp256k1.swift (~> 0.1)
-  - XMTP (0.14.13):
+  - XMTP (0.14.12):
     - Connect-Swift (= 0.12.0)
     - GzipSwift
-    - LibXMTP (= 0.5.8-beta5)
+    - LibXMTP (= 0.5.8-beta4)
     - web3.swift
-  - XMTPReactNative (2.5.4):
+  - XMTPReactNative (2.5.3):
     - ExpoModulesCore
     - MessagePacker
     - secp256k1.swift
-    - XMTP (= 0.14.13)
+    - XMTP (= 0.14.12)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1962,7 +1962,7 @@ DEPENDENCIES:
   - Sentry/HybridSDK (= 8.36.0)
   - SQLite.swift
   - UMAppLoader (from `../node_modules/unimodules-app-loader/ios`)
-  - XMTP (= 0.14.13)
+  - XMTP (= 0.14.12)
   - "XMTPReactNative (from `../node_modules/@xmtp/react-native-sdk/ios`)"
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -2267,7 +2267,7 @@ SPEC CHECKSUMS:
   ComputableLayout: c50faffac4ed9f8f05b0ce5e6f3a60df1f6042c8
   Connect-Swift: 1de2ef4a548c59ecaeb9120812dfe0d6e07a0d47
   ContextMenuAuxiliaryPreview: 484e47f66bcb9ffe485b5e7e34cc968ff3218a9f
-  DGSwiftUtilities: 1f2722e8b2442dc11c17b66818f62b93780e95fd
+  DGSwiftUtilities: 626565e1ee90ddacebd8520ea1ce730110ad13e4
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   EASClient: 1509a9a6b48b932ec61667644634daf2562983b8
   EXApplication: c08200c34daca7af7fd76ac4b9d606077410e8ad
@@ -2316,7 +2316,7 @@ SPEC CHECKSUMS:
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
-  LibXMTP: ee1591fdb51bc6cc690c1a9ba10792ccc2104328
+  LibXMTP: 81b4f2952a2dccc0392773f9c7d43d478a6117e3
   Logging: 9ef4ecb546ad3169398d5a723bc9bea1c46bef26
   MessagePacker: ab2fe250e86ea7aedd1a9ee47a37083edd41fd02
   MMKV: f902fb6719da13c2ab0965233d8963a59416f911
@@ -2416,10 +2416,10 @@ SPEC CHECKSUMS:
   SwiftProtobuf: 407a385e97fd206c4fbe880cc84123989167e0d1
   UMAppLoader: f17a5ee8e85b536ace0fc254b447a37ed198d57e
   web3.swift: 2263d1e12e121b2c42ffb63a5a7beb1acaf33959
-  XMTP: a9e7382ec5b57eeda3df7b177f034d061e3c9b61
-  XMTPReactNative: 63c46d6ba9b8dc5831ea49e8716f4b60cc012651
+  XMTP: 9346396763b21176eae6a02692536b06922589b3
+  XMTPReactNative: 3f1b362ca29149ebb02d353b703c56c7f170f753
   Yoga: 1ab23c1835475da69cf14e211a560e73aab24cb0
 
-PODFILE CHECKSUM: beb6a8b55061fc0f811288dc66c75239474eba01
+PODFILE CHECKSUM: e95146223628ee78bcf382972fdd2ff9ce07ffff
 
 COCOAPODS: 1.15.2

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@xmtp/content-type-transaction-reference": "^1.0.3",
     "@xmtp/frames-client": "^0.5.0",
     "@xmtp/proto": "^3.60.0",
-    "@xmtp/react-native-sdk": "^2.5.4",
+    "@xmtp/react-native-sdk": "2.5.3",
     "@xmtp/xmtp-js": "11.5.0",
     "amazon-cognito-identity-js": "^6.3.12",
     "axios": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9574,10 +9574,10 @@
     rxjs "^7.8.0"
     undici "^5.8.1"
 
-"@xmtp/react-native-sdk@^2.5.4":
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/@xmtp/react-native-sdk/-/react-native-sdk-2.5.4.tgz#6869eeaa0f479971b923ca67ee54784d6e15d748"
-  integrity sha512-oujHd59zJpbMtT1IzL7K2YlhcYEU7u9hcH2fRw5xAgttqecYxTWZmzqHCKLD7t6RxuCBr/4adXSFqhmaJPpAJA==
+"@xmtp/react-native-sdk@2.5.3":
+  version "2.5.3"
+  resolved "https://registry.npmjs.org/@xmtp/react-native-sdk/-/react-native-sdk-2.5.3.tgz#98f189226d547f17f685be8fd357c4203137d939"
+  integrity sha512-pVCpDYCE1YkD0OBY0fPG4omKZiKGneikLEViZxXI1nmmXodLDl+VYzJzEB+zgw0HMIe0aqyaZ8l9YyruG1wH8Q==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@msgpack/msgpack" "^3.0.0-beta2"


### PR DESCRIPTION
See sentry https://converse-app.sentry.io/share/issue/d8cbd65892474a1689ad63c996f1e238/

Reverting latest sdk update fixes this issue. 

Guessing the issue was introduced here - https://github.com/xmtp/libxmtp/pull/1054

Interestingly, in XMTP RN SDK tests for client creation all pass, so not sure if those tests are missing something, or if Converse is doing something unexpected with client creation that is causing this issue. 


 <img src="https://github.com/user-attachments/assets/fd44ad28-7688-466e-8470-1e6e06496109" width="200"/>



<img width="200" alt="image" src="https://github.com/user-attachments/assets/65a3794f-0ddc-4828-9472-f0ca0e50690d">



