### PR TITLE
fix: delete wrong account

### DIFF
--- a/components/AccountSettingsButton.tsx
+++ b/components/AccountSettingsButton.tsx
@@ -58,7 +58,7 @@ export default function AccountSettingsButton({ account, navigation }: Props) {
   );
   const erroredAccountsMap = useErroredAccountsMap();
   const colorScheme = useColorScheme();
-  const showDisconnectActionSheet = useDisconnectActionSheet();
+  const showDisconnectActionSheet = useDisconnectActionSheet(account);
 
   const onPress = useCallback(() => {
     Keyboard.dismiss();

--- a/hooks/useDisconnectActionSheet.ts
+++ b/hooks/useDisconnectActionSheet.ts
@@ -10,9 +10,9 @@ import {
 } from "../data/store/accountsStore";
 import { useLogoutFromConverse } from "../utils/logout";
 
-export const useDisconnectActionSheet = () => {
-  const account = useAccountsStore((s) => s.currentAccount);
-  const logout = useLogoutFromConverse(account);
+export const useDisconnectActionSheet = (account?: string) => {
+  const currentAccount = useAccountsStore((s) => s.currentAccount);
+  const logout = useLogoutFromConverse(account || currentAccount);
   const { ephemeralAccount } = useSettingsStore((s) => ({
     ephemeralAccount: s.ephemeralAccount,
   }));


### PR DESCRIPTION
Accounts can either be deleted from the profile page or from the accounts list. In both cases, an action sheet is shown to confirm the deletion. This action sheet was always deleting the current account, even if a different account was selected for deletion from the accounts list.
