### PR TITLE
feat: default usernames for ephemeral accounts

### DIFF
--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -122,8 +122,9 @@ const en = {
     },
     inputs: {
       username: {
-        placeholder: "Identity (.converse.xyz)",
+        placeholder: "Username",
       },
+      usernameSuffix: ".converse.xyz",
       displayName: {
         placeholder: "Display name (optional)",
       },

--- a/utils/str.ts
+++ b/utils/str.ts
@@ -77,6 +77,14 @@ export const conversationName = (
 export const formatGroupName = (topic: string, groupName?: string) =>
   groupName || capitalize(humanize(topic.slice(14, 46), 3, " "));
 
+export const formatEphemeralUsername = (address: string, username?: string) =>
+  username || humanize(address.slice(2, 42), 2, "");
+
+export const formatEphemeralDisplayName = (
+  address: string,
+  displayName?: string
+) => displayName || capitalize(humanize(address.slice(2, 42), 2, "", true));
+
 export const getTitleFontScale = (): number => {
   let titleFontScale = 1;
   const fontScale = PixelRatio.getFontScale();

--- a/utils/str.ts
+++ b/utils/str.ts
@@ -83,7 +83,7 @@ export const formatEphemeralUsername = (address: string, username?: string) =>
 export const formatEphemeralDisplayName = (
   address: string,
   displayName?: string
-) => displayName || capitalize(humanize(address.slice(2, 42), 2, "", true));
+) => displayName || humanize(address.slice(2, 42), 2, "", true);
 
 export const getTitleFontScale = (): number => {
   let titleFontScale = 1;

--- a/vendor/humanhash.js
+++ b/vendor/humanhash.js
@@ -1,4 +1,6 @@
-﻿const wordlist = [
+﻿import { capitalize } from "../utils/str";
+
+const wordlist = [
   "ack",
   "alabama",
   "alanine",
@@ -257,7 +259,7 @@
   "zulu",
 ];
 
-export const humanize = function (digest, numWords, separator) {
+export const humanize = function (digest, numWords, separator, shouldCapitalize) {
   var chars,
     i,
     len,
@@ -268,7 +270,8 @@ export const humanize = function (digest, numWords, separator) {
 
   // defaults
   numWords = numWords || 4;
-  separator = separator || "-";
+  separator = (separator !== undefined && separator !== null) ? separator : "-";
+  shouldCapitalize = shouldCapitalize || false;
 
   if (!/^[a-fA-F0-9]+$/.test(digest)) {
     throw new Error("`digest` must be hexadecimal characters only.");
@@ -286,7 +289,7 @@ export const humanize = function (digest, numWords, separator) {
   compressedBytes = compress(bytes, numWords);
 
   for (var i = 0; i < numWords; i += 1) {
-    output.push(wordlist[compressedBytes[i]]);
+    output.push(shouldCapitalize ? capitalize(wordlist[compressedBytes[i]]) : wordlist[compressedBytes[i]]);
   }
 
   return output.join(separator);


### PR DESCRIPTION
Thinking up a pseudonymous username is hard. This provides a generated default.

Future: make usernames optional for ephemeral accounts.
