### PR TITLE
Noe/frames & conversation list improvements

### DIFF
--- a/components/Chat/Frame/FramesPreviews.tsx
+++ b/components/Chat/Frame/FramesPreviews.tsx
@@ -31,6 +31,9 @@ export default function FramesPreviews({ message }: Props) {
   });
 
   const fetchTagsIfNeeded = useCallback(() => {
+    if (!tagsFetchedOnceForMessage.current) {
+      tagsFetchedOnceForMessage.current = {};
+    }
     if (!tagsFetchedOnceForMessage.current[message.id]) {
       tagsFetchedOnceForMessage.current[message.id] = true;
       fetchFramesForMessage(account, message).then(

--- a/components/Chat/Frame/FramesPreviews.tsx
+++ b/components/Chat/Frame/FramesPreviews.tsx
@@ -1,3 +1,4 @@
+import { useConversationContext } from "@utils/conversation";
 import { useCallback, useRef, useState } from "react";
 import { View } from "react-native";
 
@@ -17,8 +18,8 @@ type Props = {
 
 export default function FramesPreviews({ message }: Props) {
   const messageId = useRef<string | undefined>(undefined);
-  const tagsFetchedOnceForMessage = useRef<{ [messageId: string]: boolean }>(
-    {}
+  const tagsFetchedOnceForMessage = useConversationContext(
+    "tagsFetchedOnceForMessage"
   );
   const account = useCurrentAccount() as string;
   const [framesForMessage, setFramesForMessage] = useState<{
@@ -38,7 +39,7 @@ export default function FramesPreviews({ message }: Props) {
         }
       );
     }
-  }, [account, message]);
+  }, [account, message, tagsFetchedOnceForMessage]);
 
   // Components are recycled, let's fix when stuff changes
   if (message.id !== messageId.current) {

--- a/components/Chat/Frame/FramesPreviews.tsx
+++ b/components/Chat/Frame/FramesPreviews.tsx
@@ -31,9 +31,6 @@ export default function FramesPreviews({ message }: Props) {
   });
 
   const fetchTagsIfNeeded = useCallback(() => {
-    if (!tagsFetchedOnceForMessage.current) {
-      tagsFetchedOnceForMessage.current = {};
-    }
     if (!tagsFetchedOnceForMessage.current[message.id]) {
       tagsFetchedOnceForMessage.current[message.id] = true;
       fetchFramesForMessage(account, message).then(

--- a/components/Chat/Message/MessageContextMenu.tsx
+++ b/components/Chat/Message/MessageContextMenu.tsx
@@ -9,6 +9,7 @@ import {
   SIDE_MARGIN,
   SPRING_CONFIGURATION,
 } from "@utils/contextMenu/constants";
+import { ConversationContext } from "@utils/conversation";
 import { BlurView } from "expo-blur";
 import React, { FC, memo, useEffect, useMemo } from "react";
 import {
@@ -31,6 +32,7 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useContext } from "use-context-selector";
 const AnimatedBlurView =
   Platform.OS === "ios"
     ? Animated.createAnimatedComponent(BlurView)
@@ -59,6 +61,10 @@ const BackdropComponent: FC<{
   items,
   fromMe,
 }) => {
+  /* Portal is eating the context so passing down context values
+    If it causes too many rerenders we could just pass down a
+    few needed context values but painful to maintain */
+  const conversationContext = useContext(ConversationContext);
   const activeValue = useSharedValue(false);
   const opacityValue = useSharedValue(0);
   const intensityValue = useSharedValue(0);
@@ -218,35 +224,38 @@ const BackdropComponent: FC<{
 
   return (
     <Portal>
-      <GestureHandlerRootView style={styles.gestureHandlerContainer}>
-        <AnimatedBlurView
-          tint="default"
-          style={styles.flex}
-          animatedProps={animatedContainerProps}
-        >
-          <TouchableWithoutFeedback onPress={onClose}>
-            <Animated.View
-              style={[StyleSheet.absoluteFill, animatedInnerContainerStyle]}
-            >
-              <Animated.View style={animatedPortalStyle}>
-                {children}
+      {/* Portal is eating the context so passing down context values */}
+      <ConversationContext.Provider value={conversationContext}>
+        <GestureHandlerRootView style={styles.gestureHandlerContainer}>
+          <AnimatedBlurView
+            tint="default"
+            style={styles.flex}
+            animatedProps={animatedContainerProps}
+          >
+            <TouchableWithoutFeedback onPress={onClose}>
+              <Animated.View
+                style={[StyleSheet.absoluteFill, animatedInnerContainerStyle]}
+              >
+                <Animated.View style={animatedPortalStyle}>
+                  {children}
+                </Animated.View>
+                <Animated.View style={animatedAuxiliaryViewStyle}>
+                  {auxiliaryView}
+                </Animated.View>
+                <Animated.View style={animatedMenuStyle}>
+                  <TableView
+                    style={{
+                      // flex: 1,
+                      width: ITEM_WIDTH,
+                    }}
+                    items={items}
+                  />
+                </Animated.View>
               </Animated.View>
-              <Animated.View style={animatedAuxiliaryViewStyle}>
-                {auxiliaryView}
-              </Animated.View>
-              <Animated.View style={animatedMenuStyle}>
-                <TableView
-                  style={{
-                    // flex: 1,
-                    width: ITEM_WIDTH,
-                  }}
-                  items={items}
-                />
-              </Animated.View>
-            </Animated.View>
-          </TouchableWithoutFeedback>
-        </AnimatedBlurView>
-      </GestureHandlerRootView>
+            </TouchableWithoutFeedback>
+          </AnimatedBlurView>
+        </GestureHandlerRootView>
+      </ConversationContext.Provider>
     </Portal>
   );
 };

--- a/components/ConversationFlashList.tsx
+++ b/components/ConversationFlashList.tsx
@@ -2,6 +2,7 @@ import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { FlashList } from "@shopify/flash-list";
 import { backgroundColor } from "@styles/colors";
 import { showUnreadOnConversation } from "@utils/conversation/showUnreadOnConversation";
+import { ConversationListContext } from "@utils/conversationList";
 import { useCallback, useEffect, useRef } from "react";
 import { Platform, StyleSheet, View, useColorScheme } from "react-native";
 
@@ -43,6 +44,10 @@ export default function ConversationFlashList({
   ListHeaderComponent,
   ListFooterComponent,
 }: Props) {
+  const navigationRef = useRef(navigation);
+  useEffect(() => {
+    navigationRef.current = navigation;
+  }, [navigation]);
   const styles = useStyles();
   const colorScheme = useColorScheme();
   const {
@@ -103,18 +108,10 @@ export default function ConversationFlashList({
         ? profiles[conversation.peerAddress]?.socials
         : undefined;
       if (conversation.isGroup) {
-        return (
-          <GroupConversationItem
-            conversation={conversation}
-            navigation={navigation}
-            route={route}
-          />
-        );
+        return <GroupConversationItem conversation={conversation} />;
       }
       return (
         <ConversationListItem
-          navigation={navigation}
-          route={route}
           conversationPeerAddress={conversation.peerAddress}
           conversationPeerAvatar={getPreferredAvatar(socials)}
           colorScheme={colorScheme}
@@ -152,46 +149,52 @@ export default function ConversationFlashList({
     [
       colorScheme,
       initialLoadDoneOnce,
-      navigation,
       openedConversationTopic,
       peersStatus,
-      route,
+      profiles,
       topicsData,
       userAddress,
-      profiles,
     ]
   );
   return (
-    <View style={styles.container}>
-      <View style={styles.conversationList}>
-        <FlashList
-          keyboardShouldPersistTaps="handled"
-          onMomentumScrollBegin={onScroll}
-          onScrollBeginDrag={onScroll}
-          alwaysBounceVertical={items.length > 0}
-          contentInsetAdjustmentBehavior="automatic"
-          data={items}
-          extraData={[
-            colorScheme,
-            navigation,
-            route,
-            userAddress,
-            initialLoadDoneOnce,
-            lastUpdateAt,
-          ]}
-          ref={(r) => {
-            if (r) {
-              listRef.current = r;
-            }
-          }}
-          renderItem={renderItem}
-          keyExtractor={keyExtractor}
-          estimatedItemSize={Platform.OS === "ios" ? 77 : 88}
-          ListHeaderComponent={ListHeaderComponent}
-          ListFooterComponent={ListFooterComponent}
-        />
+    <ConversationListContext.Provider
+      value={{
+        navigationRef,
+        routeName: route.name,
+        routeParams: route.params,
+      }}
+    >
+      <View style={styles.container}>
+        <View style={styles.conversationList}>
+          <FlashList
+            keyboardShouldPersistTaps="handled"
+            onMomentumScrollBegin={onScroll}
+            onScrollBeginDrag={onScroll}
+            alwaysBounceVertical={items.length > 0}
+            contentInsetAdjustmentBehavior="automatic"
+            data={items}
+            extraData={[
+              colorScheme,
+              navigation,
+              route,
+              userAddress,
+              initialLoadDoneOnce,
+              lastUpdateAt,
+            ]}
+            ref={(r) => {
+              if (r) {
+                listRef.current = r;
+              }
+            }}
+            renderItem={renderItem}
+            keyExtractor={keyExtractor}
+            estimatedItemSize={Platform.OS === "ios" ? 77 : 88}
+            ListHeaderComponent={ListHeaderComponent}
+            ListFooterComponent={ListFooterComponent}
+          />
+        </View>
       </View>
-    </View>
+    </ConversationListContext.Provider>
   );
 }
 

--- a/components/ConversationFlashList.tsx
+++ b/components/ConversationFlashList.tsx
@@ -63,10 +63,6 @@ export default function ConversationFlashList({
   const isSplitScreen = useIsSplitScreen();
   const profiles = useProfilesStore((state) => state.profiles);
 
-  const setPinnedConversations = useChatStore(
-    (state) => state.setPinnedConversations
-  );
-
   const listRef = useRef<FlashList<any> | undefined>();
 
   const previousSearchQuery = useRef(itemsForSearchQuery);
@@ -117,9 +113,6 @@ export default function ConversationFlashList({
       }
       return (
         <ConversationListItem
-          onLongPress={() => {
-            setPinnedConversations([conversation]);
-          }}
           navigation={navigation}
           route={route}
           conversationPeerAddress={conversation.peerAddress}
@@ -166,7 +159,6 @@ export default function ConversationFlashList({
       topicsData,
       userAddress,
       profiles,
-      setPinnedConversations,
     ]
   );
   return (

--- a/components/ConversationList/GroupConversationItem.tsx
+++ b/components/ConversationList/GroupConversationItem.tsx
@@ -3,7 +3,6 @@ import { useGroupConsent } from "@hooks/useGroupConsent";
 import { translate } from "@i18n";
 import { useGroupNameQuery } from "@queries/useGroupNameQuery";
 import { useGroupPhotoQuery } from "@queries/useGroupPhotoQuery";
-import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { actionSheetColors } from "@styles/colors";
 import { showUnreadOnConversation } from "@utils/conversation/showUnreadOnConversation";
 import { FC, useCallback } from "react";
@@ -14,22 +13,15 @@ import {
   useCurrentAccount,
 } from "../../data/store/accountsStore";
 import { useSelect } from "../../data/store/storeHelpers";
-import { NavigationParamList } from "../../screens/Navigation/Navigation";
 import { ConversationWithLastMessagePreview } from "../../utils/conversation";
 import { conversationName } from "../../utils/str";
 import ConversationListItem from "../ConversationListItem";
 
-interface GroupConversationItemProps
-  extends NativeStackScreenProps<
-    NavigationParamList,
-    "Chats" | "ShareFrame" | "ChatsRequests" | "Blocked"
-  > {
+interface GroupConversationItemProps {
   conversation: ConversationWithLastMessagePreview;
 }
 
 export const GroupConversationItem: FC<GroupConversationItemProps> = ({
-  navigation,
-  route,
   conversation,
 }) => {
   const userAddress = useCurrentAccount() as string;
@@ -136,8 +128,6 @@ export const GroupConversationItem: FC<GroupConversationItemProps> = ({
 
   return (
     <ConversationListItem
-      navigation={navigation}
-      route={route}
       conversationPeerAddress={conversation.peerAddress}
       conversationPeerAvatar={groupPhoto}
       colorScheme={colorScheme}

--- a/components/ConversationList/GroupConversationItem.tsx
+++ b/components/ConversationList/GroupConversationItem.tsx
@@ -51,26 +51,14 @@ export const GroupConversationItem: FC<GroupConversationItemProps> = ({
     gcTime: Infinity,
   });
   const colorScheme = useColorScheme();
-  const {
-    initialLoadDoneOnce,
-    openedConversationTopic,
-    topicsData,
-    setPinnedConversations,
-  } = useChatStore(
-    useSelect([
-      "initialLoadDoneOnce",
-      "openedConversationTopic",
-      "topicsData",
-      "setPinnedConversations",
-    ])
-  );
-
-  const onLongPress = useCallback(() => {
-    // Prevent this for blocked chats
-    if (consent !== "denied") {
-      setPinnedConversations([conversation]);
-    }
-  }, [setPinnedConversations, conversation, consent]);
+  const { initialLoadDoneOnce, openedConversationTopic, topicsData } =
+    useChatStore(
+      useSelect([
+        "initialLoadDoneOnce",
+        "openedConversationTopic",
+        "topicsData",
+      ])
+    );
 
   const handleRemove = useCallback(
     (defaultAction: () => void) => {
@@ -148,7 +136,6 @@ export const GroupConversationItem: FC<GroupConversationItemProps> = ({
 
   return (
     <ConversationListItem
-      onLongPress={onLongPress}
       navigation={navigation}
       route={route}
       conversationPeerAddress={conversation.peerAddress}

--- a/components/ConversationListItem.tsx
+++ b/components/ConversationListItem.tsx
@@ -1,7 +1,6 @@
 import { useSelect } from "@data/store/storeHelpers";
 import { useGroupConsent } from "@hooks/useGroupConsent";
 import { translate } from "@i18n";
-import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import {
   actionSheetColors,
   backgroundColor,
@@ -13,6 +12,7 @@ import {
   textSecondaryColor,
 } from "@styles/colors";
 import { AvatarSizes, PictoSizes } from "@styles/sizes";
+import { useConversationListContext } from "@utils/conversationList";
 import * as Haptics from "expo-haptics";
 import { Image } from "expo-image";
 import React, {
@@ -44,7 +44,6 @@ import {
   useChatStore,
   useSettingsStore,
 } from "../data/store/accountsStore";
-import { NavigationParamList } from "../screens/Navigation/Navigation";
 import { useIsSplitScreen } from "../screens/Navigation/navHelpers";
 import { saveTopicsData } from "../utils/api";
 import { getMinimalDate } from "../utils/date";
@@ -74,14 +73,9 @@ type ConversationListItemProps = {
   conversationOpened: boolean;
   isGroupConversation: boolean;
   onRightActionPress?: (defaultAction: () => void) => void;
-} & NativeStackScreenProps<
-  NavigationParamList,
-  "Chats" | "ShareFrame" | "ChatsRequests" | "Blocked"
->;
+};
 
 const ConversationListItem = memo(function ConversationListItem({
-  navigation,
-  route,
   colorScheme,
   conversationTopic,
   conversationTime,
@@ -110,7 +104,10 @@ const ConversationListItem = memo(function ConversationListItem({
   }, []);
   const hasImagePreview = lastMessageImageUrl && lastMessagePreview;
   const showError = lastMessageFromMe && lastMessageStatus === "error";
-  const isBlockedChatView = route.name === "Blocked";
+  const routeName = useConversationListContext("routeName");
+  const routeParams = useConversationListContext("routeParams");
+  const navigationRef = useConversationListContext("navigationRef");
+  const isBlockedChatView = routeName === "Blocked";
   const { allowGroup } = useGroupConsent(conversationTopic);
 
   const openConversation = useCallback(async () => {
@@ -124,7 +121,7 @@ const ConversationListItem = memo(function ConversationListItem({
           });
           // Take the user back to wherever the conversation was restored "to"
           // https://github.com/ephemeraHQ/converse-app/issues/315#issuecomment-2312903441
-          navigation.pop(isSplitScreen ? 1 : 2);
+          navigationRef.current?.pop(isSplitScreen ? 1 : 2);
         },
         [translate("cancel")]: () => {},
       };
@@ -163,9 +160,9 @@ const ConversationListItem = memo(function ConversationListItem({
     }
 
     // Open conversation
-    if (route.params?.frameURL) {
+    if (routeParams?.frameURL) {
       // Sharing a frame !!
-      navigation.goBack();
+      navigationRef.current?.goBack();
       if (!isSplitScreen) {
         await new Promise((r) =>
           setTimeout(r, Platform.OS === "ios" ? 300 : 20)
@@ -174,7 +171,7 @@ const ConversationListItem = memo(function ConversationListItem({
       // This handle the case where the conversation is already opened
       converseEventEmitter.emit(
         "setCurrentConversationInputValue",
-        route.params.frameURL
+        routeParams.frameURL
       );
     }
     if (isDesktop) {
@@ -184,25 +181,26 @@ const ConversationListItem = memo(function ConversationListItem({
     }
     navigate("Conversation", {
       topic: conversationTopic,
-      message: route.params?.frameURL,
+      message: routeParams?.frameURL,
     });
   }, [
-    conversationTopic,
-    isSplitScreen,
-    navigation,
-    route.params?.frameURL,
-    colorScheme,
     isGroupConversation,
     isBlockedChatView,
+    routeParams?.frameURL,
+    conversationTopic,
     allowGroup,
+    navigationRef,
+    isSplitScreen,
+    colorScheme,
   ]);
 
   useEffect(() => {
-    navigation.addListener("transitionEnd", resetSelected);
+    const navRef = navigationRef.current;
+    navRef?.addListener("transitionEnd", resetSelected);
     return () => {
-      navigation.removeListener("transitionEnd", resetSelected);
+      navRef?.removeListener("transitionEnd", resetSelected);
     };
-  }, [navigation, resetSelected]);
+  }, [navigationRef, resetSelected]);
 
   const avatarComponent = useMemo(() => {
     return isGroupConversation ? (

--- a/components/ConversationListItem.tsx
+++ b/components/ConversationListItem.tsx
@@ -108,7 +108,11 @@ const ConversationListItem = memo(function ConversationListItem({
   const routeParams = useConversationListContext("routeParams");
   const navigationRef = useConversationListContext("navigationRef");
   const isBlockedChatView = routeName === "Blocked";
-  const { allowGroup } = useGroupConsent(conversationTopic);
+  const { allowGroup } = useGroupConsent(conversationTopic, {
+    refetchOnMount: false,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
 
   const openConversation = useCallback(async () => {
     const getUserAction = async () => {

--- a/components/ConversationListItem.tsx
+++ b/components/ConversationListItem.tsx
@@ -1,3 +1,4 @@
+import { useSelect } from "@data/store/storeHelpers";
 import { useGroupConsent } from "@hooks/useGroupConsent";
 import { translate } from "@i18n";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
@@ -72,7 +73,6 @@ type ConversationListItemProps = {
   showUnread: boolean;
   conversationOpened: boolean;
   isGroupConversation: boolean;
-  onLongPress?: () => void;
   onRightActionPress?: (defaultAction: () => void) => void;
 } & NativeStackScreenProps<
   NavigationParamList,
@@ -95,12 +95,13 @@ const ConversationListItem = memo(function ConversationListItem({
   showUnread,
   conversationOpened,
   isGroupConversation = false,
-  onLongPress,
   onRightActionPress,
 }: ConversationListItemProps) {
   const styles = getStyles(colorScheme);
   const timeToShow = getMinimalDate(conversationTime as number);
-  const setTopicsData = useChatStore((s) => s.setTopicsData);
+  const { setTopicsData, setPinnedConversations } = useChatStore(
+    useSelect(["setTopicsData", "setPinnedConversations"])
+  );
   const setPeersStatus = useSettingsStore((s) => s.setPeersStatus);
   const isSplitScreen = useIsSplitScreen();
   const [selected, setSelected] = useState(false);
@@ -414,6 +415,10 @@ const ConversationListItem = memo(function ConversationListItem({
       </RectButton>
     );
   }, [showUnread, styles.leftAction, colorScheme]);
+
+  const onLongPress = useCallback(() => {
+    setPinnedConversations([conversationTopic]);
+  }, [conversationTopic, setPinnedConversations]);
 
   const rowItem =
     Platform.OS === "ios" || Platform.OS === "web" ? (

--- a/components/PinnedConversations/PinnedConversation.tsx
+++ b/components/PinnedConversations/PinnedConversation.tsx
@@ -50,8 +50,8 @@ export const PinnedConversation: FC<Props> = ({ conversation }) => {
   }, [conversation.topic]);
 
   const onLongPress = useCallback(() => {
-    setPinnedConversations([conversation]);
-  }, [conversation, setPinnedConversations]);
+    setPinnedConversations([conversation.topic]);
+  }, [conversation.topic, setPinnedConversations]);
   const { initialLoadDoneOnce, topicsData } = useChatStore(
     useSelect(["initialLoadDoneOnce", "topicsData"])
   );

--- a/screens/Conversation.tsx
+++ b/screens/Conversation.tsx
@@ -45,6 +45,9 @@ const Conversation = ({
   const peersStatus = useSettingsStore((s) => s.peersStatus);
   const [transactionMode, setTransactionMode] = useState(false);
   const [frameTextInputFocused, setFrameTextInputFocused] = useState(false);
+  const tagsFetchedOnceForMessage = useRef<{ [messageId: string]: boolean }>(
+    {}
+  );
 
   const {
     conversations,
@@ -297,6 +300,7 @@ const Conversation = ({
             setTransactionMode,
             frameTextInputFocused,
             setFrameTextInputFocused,
+            tagsFetchedOnceForMessage,
           }}
         >
           <ConverseChat />

--- a/utils/conversation.ts
+++ b/utils/conversation.ts
@@ -274,6 +274,9 @@ export type ConversationContextType = {
   setTransactionMode: (b: boolean) => void;
   frameTextInputFocused: boolean;
   setFrameTextInputFocused: (b: boolean) => void;
+  tagsFetchedOnceForMessage: MutableRefObject<{
+    [messageId: string]: boolean;
+  }>;
 };
 
 export const ConversationContext = createContext<ConversationContextType>({
@@ -288,6 +291,9 @@ export const ConversationContext = createContext<ConversationContextType>({
   setTransactionMode: () => {},
   frameTextInputFocused: false,
   setFrameTextInputFocused: () => {},
+  tagsFetchedOnceForMessage: createRef() as MutableRefObject<{
+    [messageId: string]: boolean;
+  }>,
 });
 
 export const useConversationContext = <K extends keyof ConversationContextType>(

--- a/utils/conversationList.ts
+++ b/utils/conversationList.ts
@@ -1,0 +1,28 @@
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { NavigationParamList } from "@screens/Navigation/Navigation";
+import { MutableRefObject } from "react";
+import { createContext, useContextSelector } from "use-context-selector";
+
+export type ConversationListContextType = {
+  navigationRef: MutableRefObject<
+    | NativeStackScreenProps<
+        NavigationParamList,
+        "Chats" | "ShareFrame" | "ChatsRequests" | "Blocked"
+      >["navigation"]
+    | undefined
+  >;
+  routeName: "Chats" | "ShareFrame" | "ChatsRequests" | "Blocked";
+  routeParams: NativeStackScreenProps<
+    NavigationParamList,
+    "Chats" | "ShareFrame" | "ChatsRequests" | "Blocked"
+  >["route"]["params"];
+};
+
+export const ConversationListContext =
+  createContext<ConversationListContextType>({} as ConversationListContextType);
+
+export const useConversationListContext = <
+  K extends keyof ConversationListContextType,
+>(
+  key: K
+) => useContextSelector(ConversationListContext, (s) => s[key]);


### PR DESCRIPTION
A bunch of perf improvements based on latest QAs & logs

- prevent loop refetching of some frames by not refetching the frames for a given message id twice for the same "conversation display"
- prevent cell rerenders for conversationlistitem in multiple ways
  - bad onLongPress
  - navigation props updating should not cause rerenders => using a context with ref
  - allowGroup missing parameters to not refetch for each row 