### PR TITLE
Make sure to ask for user cta if no db files

### DIFF
--- a/components/Onboarding/ConnectViaWallet.tsx
+++ b/components/Onboarding/ConnectViaWallet.tsx
@@ -66,7 +66,6 @@ export default function ConnectViaWallet({
   );
   const [onXmtp, setOnXmtp] = useState(false);
   const [alreadyV3Db, setAlreadyV3Db] = useState(false);
-  const styles = useStyles();
   const thirdwebWallet = useActiveWallet();
   const thirdwebAccount = useActiveAccount();
   const [thirdwebSigner, setThirdwebSigner] = useState<Signer | undefined>();
@@ -167,7 +166,9 @@ export default function ConnectViaWallet({
           setOnXmtp(isOnNetwork);
           const inboxId = await getInboxId(a);
           const v3Dbs = await getDatabaseFilesForInboxId(inboxId);
-          setAlreadyV3Db(v3Dbs.length > 0);
+          setAlreadyV3Db(
+            v3Dbs.filter((n) => n.name.endsWith(".db3")).length > 0
+          );
           setSigner(thirdwebSigner);
           setLoading(false);
           logger.debug(

--- a/utils/logout/index.tsx
+++ b/utils/logout/index.tsx
@@ -1,3 +1,4 @@
+import { deleteLibXmtpDatabaseForInboxId } from "@utils/fileSystem";
 import logger from "@utils/logger";
 import { ConverseXmtpClientType, dropXmtpClient } from "@utils/xmtpRN/client";
 import { getInboxId } from "@utils/xmtpRN/signIn";
@@ -154,6 +155,8 @@ export const logoutAccount = async (
       if (dropLocalDatabase) {
         await client.deleteLocalDatabase();
         logger.debug("[Logout] successfully deleted libxmp db");
+        // Manual delete database files
+        await deleteLibXmtpDatabaseForInboxId(client.inboxId);
       }
     } catch (error) {
       logger.warn("Could not get XMTP Client while logging out", {


### PR DESCRIPTION
Might fix #775 but haven't reproduced on my end
Introduction of salt file was breaking our detection of 2 signatures needed so we didn't show the CTA to the user, so maybe the app was trying to trigger automatically a second signature and the OS was preventing it.

Let's see in next release if anyone still has the issues. Logs I have don't currently help.