### PR TITLE
Tap to reveal timestamps updates

### DIFF
--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -177,6 +177,9 @@ const ChatMessage = ({
   const showTime = useRef<boolean>(false);
   const showDateTime = useRef<boolean>(false);
   const animateTime = useCallback(() => {
+    if (isAttachmentMessage()) {
+      return;
+    }
     // For messages with date change
     if (message.dateChange) {
       showDateTime.current = !showDateTime.current;

--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -445,13 +445,11 @@ const ChatMessage = ({
                           fromMe={message.fromMe}
                         />
                       </TouchableOpacity>
-                      <View
-                        style={{
-                          alignSelf: "flex-start",
-                        }}
-                      >
-                        {messageContent}
-                      </View>
+                      <TouchableOpacity onPress={animateTime} activeOpacity={1}>
+                        <View style={{ alignSelf: "flex-start" }}>
+                          {messageContent}
+                        </View>
+                      </TouchableOpacity>
                     </View>
                   ) : (
                     <View


### PR DESCRIPTION
- Allow tap to reveal time on message replies
- Disable tap to reveal time on attachments since it already opens a modal

Fixes #786
