### PR TITLE
update camera and library purpose strings, remove unused permissions

### DIFF
--- a/ios/Converse/Info.plist
+++ b/ios/Converse/Info.plist
@@ -69,15 +69,9 @@
 		<true/>
 	</dict>
 	<key>NSCameraUsageDescription</key>
-	<string>Give $(PRODUCT_NAME) permission to access your camera</string>
-	<key>NSContactsUsageDescription</key>
-	<string>Allow $(PRODUCT_NAME) to access your contacts</string>
-	<key>NSFaceIDUsageDescription</key>
-	<string>$(PRODUCT_NAME) wants to use biometrics to secure your data</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Give $(PRODUCT_NAME) permission to use your microphone</string>
+	<string>We need this so that you can take photos to share.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Give $(PRODUCT_NAME) permission to access photos</string>
+	<string>We need this so that you can share photos from your library.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>INSendMessageIntent</string>


### PR DESCRIPTION
From App Store Review:
"One or more purpose strings in the app do not sufficiently explain the use of protected resources. Purpose strings must clearly and completely describe the app's use of data and, in most cases, provide an example of how the data will be used."

This PR:
- Updates purpose strings to provide the same level of detail as other messaging apps
- Removes permissions that are not currently used by the app
