### PR TITLE
add recs back to add group member screen

### DIFF
--- a/components/Recommendations/Recommendations.tsx
+++ b/components/Recommendations/Recommendations.tsx
@@ -298,6 +298,7 @@ const useStyles = () => {
         default: {
           borderBottomWidth: 0.5,
           borderBottomColor: itemSeparatorColor(colorScheme),
+          paddingLeft: 16,
         },
         android: {},
         web: {},

--- a/screens/NewConversation/NewConversation.tsx
+++ b/screens/NewConversation/NewConversation.tsx
@@ -291,11 +291,7 @@ export default function NewConversation({
   const initialFocus = useRef(false);
 
   const showRecommendations =
-    !status.loading &&
-    value.length === 0 &&
-    recommendationsFrensCount > 0 &&
-    // hide recommendations when adding users to a group
-    !route.params?.addingToGroupTopic;
+    !status.loading && value.length === 0 && recommendationsFrensCount > 0;
 
   const profiles = getProfilesStore(currentAccount()).getState().profiles;
 


### PR DESCRIPTION
Unhides matchmaker recommendations from the add group member modal. Many internal testers missed this when it was removed.
