### PR TITLE
perf improvement initial sync android + spam score fixes

### DIFF
--- a/components/ConversationFlashList.tsx
+++ b/components/ConversationFlashList.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { Platform, StyleSheet, View, useColorScheme } from "react-native";
 
 import { GroupConversationItem } from "./ConversationList/GroupConversationItem";
+import HiddenRequestsButton from "./ConversationList/HiddenRequestsButton";
 import ConversationListItem from "./ConversationListItem";
 import {
   useChatStore,
@@ -18,6 +19,7 @@ import { useSelect } from "../data/store/storeHelpers";
 import { NavigationParamList } from "../screens/Navigation/Navigation";
 import { useIsSplitScreen } from "../screens/Navigation/navHelpers";
 import {
+  ConversationFlatListHiddenRequestItem,
   ConversationFlatListItem,
   ConversationWithLastMessagePreview,
 } from "../utils/conversation";
@@ -102,6 +104,15 @@ export default function ConversationFlashList({
 
   const renderItem = useCallback(
     ({ item }: { item: ConversationFlatListItem }) => {
+      if (item.topic === "hiddenRequestsButton") {
+        const hiddenRequestItem = item as ConversationFlatListHiddenRequestItem;
+        return (
+          <HiddenRequestsButton
+            spamCount={hiddenRequestItem.spamCount}
+            toggleActivated={hiddenRequestItem.toggleActivated}
+          />
+        );
+      }
       const conversation = item as ConversationWithLastMessagePreview;
       const lastMessagePreview = conversation.lastMessagePreview;
       const socials = conversation.peerAddress

--- a/components/ConversationList/HiddenRequestsButton.tsx
+++ b/components/ConversationList/HiddenRequestsButton.tsx
@@ -8,6 +8,7 @@ import {
   textSecondaryColor,
 } from "@styles/colors";
 import { PictoSizes } from "@styles/sizes";
+import { converseEventEmitter } from "@utils/events";
 import {
   Platform,
   StyleSheet,
@@ -21,13 +22,11 @@ import Picto from "../Picto/Picto";
 
 type Props = {
   spamCount: number;
-  handlePress: () => void;
   toggleActivated: boolean;
 };
 
 export default function HiddenRequestsButton({
   spamCount,
-  handlePress,
   toggleActivated = false,
 }: Props) {
   const colorScheme = useColorScheme();
@@ -36,7 +35,9 @@ export default function HiddenRequestsButton({
     <TouchableHighlight
       underlayColor={clickedItemBackgroundColor(colorScheme)}
       key="spam"
-      onPress={handlePress}
+      onPress={() => {
+        converseEventEmitter.emit("toggleSpamRequests");
+      }}
     >
       <View style={styles.spamHeader}>
         <Text style={styles.spamHeaderTitle}>

--- a/data/helpers/conversations/spamScore.ts
+++ b/data/helpers/conversations/spamScore.ts
@@ -67,6 +67,7 @@ export const computeConversationsSpamScores = async (
   const sendersSpamScores = await getSendersSpamScores(
     Array.from(conversationsRequesterAddresses)
   );
+
   const topicSpamScores: TopicSpamScores = {};
 
   conversations.forEach((conversation) => {
@@ -80,7 +81,10 @@ export const computeConversationsSpamScores = async (
     const senderSpamScore = sendersSpamScores[senderKey];
     if (
       !conversation.messagesIds.length &&
-      typeof senderSpamScore === "number"
+      typeof senderSpamScore === "number" &&
+      // 1:1 Conversations without messages and no specific sender spam score
+      // should not get a spam score now (waiting for first message)
+      (conversation.isGroup || senderSpamScore !== 0)
     ) {
       // Cannot score an empty conversation further, score is just the
       // sender spam score

--- a/screens/ConversationList.tsx
+++ b/screens/ConversationList.tsx
@@ -39,6 +39,7 @@ import {
 import { XmtpConversation } from "../data/store/chatStore";
 import { useSelect } from "../data/store/storeHelpers";
 import {
+  ConversationFlatListItem,
   LastMessagePreview,
   getFilteredConversationsWithSearch,
 } from "../utils/conversation";
@@ -48,7 +49,6 @@ import { sortRequestsBySpamScore } from "../utils/xmtpRN/conversations";
 type ConversationWithLastMessagePreview = XmtpConversation & {
   lastMessagePreview?: LastMessagePreview;
 };
-type FlatListItem = ConversationWithLastMessagePreview | { topic: string };
 
 type Props = {
   searchBarRef:
@@ -88,7 +88,7 @@ function ConversationList({ navigation, route, searchBarRef }: Props) {
   const pinnedConversations = useChatStore((s) => s.pinnedConversations);
 
   const [flatListItems, setFlatListItems] = useState<{
-    items: FlatListItem[];
+    items: ConversationFlatListItem[];
     searchQuery: string;
   }>({ items: [], searchQuery: "" });
 

--- a/utils/conversation.ts
+++ b/utils/conversation.ts
@@ -35,9 +35,16 @@ import {
 export type ConversationWithLastMessagePreview = XmtpConversation & {
   lastMessagePreview?: LastMessagePreview;
 };
+
+export type ConversationFlatListHiddenRequestItem = {
+  topic: "hiddenRequestsButton";
+  toggleActivated: boolean;
+  spamCount: number;
+};
+
 export type ConversationFlatListItem =
   | ConversationWithLastMessagePreview
-  | { topic: string };
+  | ConversationFlatListHiddenRequestItem;
 
 export type LastMessagePreview = {
   contentPreview: string;

--- a/utils/events.ts
+++ b/utils/events.ts
@@ -25,6 +25,7 @@ type ConverseEvents = {
     messageId?: string;
     animated?: boolean;
   }) => void;
+  toggleSpamRequests: () => void;
 };
 
 type ShowActionSheetEvents = {

--- a/utils/xmtpRN/conversations.ts
+++ b/utils/xmtpRN/conversations.ts
@@ -804,7 +804,8 @@ export const sortRequestsBySpamScore = (
   requests.forEach((conversation) => {
     const isLikelyNotSpam =
       conversation.spamScore !== undefined &&
-      (conversation.spamScore === null || conversation.spamScore < 1) &&
+      conversation.spamScore !== null &&
+      conversation.spamScore < 1 &&
       conversation.version !== ConversationVersion.GROUP;
     // @todo => remove this once we have group-specific spam scores
 


### PR DESCRIPTION
Fixes for spam score and some android specific requests screen

- some clear spams were shown as non spam (1:1 conversations score was computed before we had the 1st message so we were not considering content)
- killing & reopening the app was making some hidden spam to show in likely not spam => undefined & null were not treated the same
- requests screen for android was freezing if many convos => a ConversationFlashList as a footer of another ConversationFlashList was breaking FlashList optimization. Fixed by showing the toggle as part of the flashlist and removing the Footer