### PR TITLE
feat: Better Handling with Group invites

### DIFF
--- a/containers/GroupScreenAddition.tsx
+++ b/containers/GroupScreenAddition.tsx
@@ -93,9 +93,10 @@ export const GroupScreenAddition: FC<GroupScreenAdditionProps> = ({
 
   const onCreateInviteLinkPress = useCallback(() => {
     createGroupInvite(currentAccount, {
-      groupName: groupName ?? "New Group",
+      groupName: groupName ?? translate("group_invite_default_group_name"),
       imageUrl: groupPhoto,
       description: groupDescription,
+      groupId: getGroupIdFromTopic(topic),
     })
       .then((groupInvite) => {
         saveInviteIdByGroupId(getGroupIdFromTopic(topic), groupInvite.id);

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -261,6 +261,7 @@ const en = {
   group_join_invite_invalid: "This invite is no longer valid",
   group_finished_polling: "This is taking longer than expected",
   group_already_joined: "This invite has already been accepted",
+  group_invite_default_group_name: "New Group",
 
   // Group Overview
   change_profile_picture: "Change profile picture",

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -260,6 +260,7 @@ const en = {
   group_join_error: "An error occurred",
   group_join_invite_invalid: "This invite is no longer valid",
   group_finished_polling: "This is taking longer than expected",
+  group_already_joined: "This invite has already been accepted",
 
   // Group Overview
   change_profile_picture: "Change profile picture",

--- a/utils/api.test.ts
+++ b/utils/api.test.ts
@@ -34,6 +34,7 @@ describe.skip("GroupInviteLink", () => {
   const groupName = "test";
   const description = "description";
   const imageUrl = "image";
+  const groupId = "group";
 
   beforeEach(async () => {
     client = await randomClient("dev");
@@ -44,6 +45,7 @@ describe.skip("GroupInviteLink", () => {
       groupName,
       description,
       imageUrl,
+      groupId,
     });
     expect(groupInviteLink.id).toBeDefined();
 
@@ -58,6 +60,7 @@ describe.skip("GroupInviteLink", () => {
       groupName,
       description,
       imageUrl,
+      groupId,
     });
 
     const secondClient = await randomClient("dev");
@@ -82,6 +85,7 @@ describe.skip("GroupInviteLink", () => {
       groupName,
       description,
       imageUrl,
+      groupId,
     });
 
     const secondClient = await randomClient("dev");

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -417,6 +417,7 @@ export type GroupInvite = {
   groupName: string;
   imageUrl?: string;
   description?: string;
+  groupId?: string;
 };
 
 export type CreateGroupInviteResult = Pick<GroupInvite, "id" | "inviteLink">;
@@ -428,6 +429,7 @@ export const createGroupInvite = async (
     groupName: string;
     description?: string;
     imageUrl?: string;
+    groupId: string;
   }
 ): Promise<CreateGroupInviteResult> => {
   const { data } = await api.post("/api/groupInvite", inputs, {
@@ -460,6 +462,7 @@ export type GroupJoinRequest = {
   groupName: string;
   imageUrl?: string;
   description?: string;
+  groupId?: string;
 };
 
 // Create a group join request based on an invite ID.

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -455,9 +455,15 @@ export const deleteGroupInvite = async (
   });
 };
 
+export type GroupJoinRequestStatus =
+  | "PENDING"
+  | "ACCEPTED"
+  | "REJECTED"
+  | "ERROR";
+
 export type GroupJoinRequest = {
   id: string;
-  status: "PENDING" | "ACCEPTED" | "REJECTED" | "ERROR";
+  status: GroupJoinRequestStatus;
   invitedByAddress: string;
   groupName: string;
   imageUrl?: string;

--- a/utils/groupUtils/groupId.ts
+++ b/utils/groupUtils/groupId.ts
@@ -7,3 +7,7 @@ export const getGroupIdFromTopic = (topic: string) => {
 export const isGroupTopic = (topic: string) => {
   return topic.startsWith(GROUP_TOPIC_PREFIX);
 };
+
+export const getTopicFromGroupId = (groupId: string) => {
+  return `${GROUP_TOPIC_PREFIX}${groupId}/proto`;
+};


### PR DESCRIPTION
Added handling for Group Ids on Group requests
Navigate the user to the screen when already joined
Inform the user the invite is no longer valid if they have been removed/group is not active

https://github.com/user-attachments/assets/b1aa14cd-e669-4b9d-a6c3-64ba134bc476


