### PR TITLE
Version bump to 2.0.1

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,12 +1,12 @@
 {
   "expo": {
     "ios": {
-      "version": "1.4.9",
-      "buildNumber": "277"
+      "version": "2.0.1",
+      "buildNumber": "1"
     },
     "android": {
-      "version": "1.4.9",
-      "versionCode": 198
+      "version": "2.0.1",
+      "versionCode": 1
     }
   }
 }


### PR DESCRIPTION
v2.0.0 was approved in App Store. To submit the new build that fixes group links, we need to bump to the next version.