### PR TITLE
Chat component refactor

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -53,9 +53,72 @@ import { UUID_REGEX } from "../../utils/regex";
 import { isContentType } from "../../utils/xmtpRN/contentTypes";
 import { Recommendation } from "../Recommendations/Recommendation";
 
+const usePeerSocials = () => {
+  const conversation = useConversationContext("conversation");
+  const peerSocials = useProfilesStore(
+    useShallow((s) =>
+      conversation?.peerAddress
+        ? getProfile(conversation.peerAddress, s.profiles)?.socials
+        : undefined
+    )
+  );
+
+  return peerSocials;
+};
+
+const useRenderItem = (
+  xmtpAddress: string,
+  conversation: any,
+  framesStore: any,
+  colorScheme: any
+) =>
+  useCallback(
+    ({ item }: { item: MessageToDisplay }) => {
+      return (
+        <CachedChatMessage
+          account={xmtpAddress}
+          message={{ ...item }}
+          colorScheme={colorScheme}
+          isGroup={!!conversation?.isGroup}
+          isFrame={!!framesStore[item.content.toLowerCase()]}
+        />
+      );
+    },
+    [colorScheme, xmtpAddress, conversation?.isGroup, framesStore]
+  );
+
+const getItemType = (framesStore: any) => (item: MessageToDisplay) => {
+  const fromMeString = item.fromMe ? "fromMe" : "notFromMe";
+  if (
+    isContentType("text", item.contentType) &&
+    item.converseMetadata?.frames?.[0]
+  ) {
+    const frameUrl = item.converseMetadata?.frames?.[0];
+    const frame = framesStore[frameUrl];
+    // Recycle frames with the same aspect ratio
+    return `FRAME-${
+      frame?.frameInfo?.image?.aspectRatio || "1.91.1"
+    }-${fromMeString}`;
+  } else if (
+    (isContentType("attachment", item.contentType) ||
+      isContentType("remoteAttachment", item.contentType)) &&
+    item.converseMetadata?.attachment?.size?.height &&
+    item.converseMetadata?.attachment?.size?.width
+  ) {
+    const aspectRatio = (
+      item.converseMetadata.attachment.size.width /
+      item.converseMetadata.attachment.size.height
+    ).toFixed(2);
+    return `ATTACHMENT-${aspectRatio}-${fromMeString}`;
+  } else {
+    return `${item.contentType}-${fromMeString}`;
+  }
+};
+
 const getListArray = (
   xmtpAddress?: string,
-  conversation?: XmtpConversationWithUpdate
+  conversation?: XmtpConversationWithUpdate,
+  lastMessages?: number // Optional parameter to limit the number of messages
 ) => {
   const messageAttachments = useChatStore.getState().messageAttachments;
   const isAttachmentLoading = (messageId: string) => {
@@ -170,10 +233,15 @@ const getListArray = (
     reverseArray.push(message);
   }
 
+  // If lastMessages is defined, slice the array to return only the last n messages
+  if (lastMessages !== undefined) {
+    return reverseArray.slice(0, lastMessages);
+  }
+
   return reverseArray;
 };
 
-export default function Chat({ readOnly = false }: { readOnly?: boolean }) {
+export function Chat() {
   const conversation = useConversationContext("conversation");
   const isBlockedPeer = useConversationContext("isBlockedPeer");
   const onReadyToFocus = useConversationContext("onReadyToFocus");
@@ -181,24 +249,20 @@ export default function Chat({ readOnly = false }: { readOnly?: boolean }) {
   const frameTextInputFocused = useConversationContext("frameTextInputFocused");
 
   const xmtpAddress = useCurrentAccount() as string;
-  const peerSocials = useProfilesStore(
-    useShallow((s) =>
-      conversation?.peerAddress
-        ? getProfile(conversation.peerAddress, s.profiles)?.socials
-        : undefined
-    )
-  );
+  const peerSocials = usePeerSocials();
   const isSplitScreen = useIsSplitScreen();
   const recommendationsData = useRecommendationsStore(
     useShallow((s) =>
       conversation?.peerAddress ? s.frens[conversation.peerAddress] : undefined
     )
   );
+
   const colorScheme = useColorScheme();
   const styles = useStyles();
   const messageAttachmentsLength = useChatStore(
     useShallow((s) => Object.keys(s.messageAttachments).length)
   );
+
   const listArray = useMemo(
     () => getListArray(xmtpAddress, conversation),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -249,20 +313,12 @@ export default function Chat({ readOnly = false }: { readOnly?: boolean }) {
   const chatContentStyle = useAnimatedStyle(
     () => ({
       ...styles.chatContent,
-      paddingBottom: readOnly
-        ? 0 // Remove bottom padding if readOnly is true
-        : showChatInput
+      paddingBottom: showChatInput
         ? chatInputDisplayedHeight.value +
           Math.max(insets.bottom, keyboardHeight.value)
         : insets.bottom,
     }),
-    [
-      showChatInput,
-      keyboardHeight,
-      chatInputDisplayedHeight,
-      insets.bottom,
-      readOnly,
-    ]
+    [showChatInput, keyboardHeight, chatInputDisplayedHeight, insets.bottom]
   );
 
   const ListFooterComponent = useMemo(() => {
@@ -284,23 +340,15 @@ export default function Chat({ readOnly = false }: { readOnly?: boolean }) {
     recommendationsData,
     styles.inChatRecommendations,
   ]);
-  const framesStore = useFramesStore().frames;
 
+  const framesStore = useFramesStore().frames;
   const showPlaceholder =
     listArray.length === 0 || isBlockedPeer || !conversation;
-  const renderItem = useCallback(
-    ({ item }: { item: MessageToDisplay }) => {
-      return (
-        <CachedChatMessage
-          account={xmtpAddress}
-          message={{ ...item }}
-          colorScheme={colorScheme}
-          isGroup={!!conversation?.isGroup}
-          isFrame={!!framesStore[item.content.toLowerCase()]}
-        />
-      );
-    },
-    [colorScheme, xmtpAddress, conversation?.isGroup, framesStore]
+  const renderItem = useRenderItem(
+    xmtpAddress,
+    conversation,
+    framesStore,
+    colorScheme
   );
   const keyExtractor = useCallback((item: MessageToDisplay) => item.id, []);
 
@@ -343,36 +391,7 @@ export default function Chat({ readOnly = false }: { readOnly?: boolean }) {
     };
   }, [scrollToMessage]);
 
-  const getItemType = useCallback(
-    (item: MessageToDisplay) => {
-      const fromMeString = item.fromMe ? "fromMe" : "notFromMe";
-      if (
-        isContentType("text", item.contentType) &&
-        item.converseMetadata?.frames?.[0]
-      ) {
-        const frameUrl = item.converseMetadata?.frames?.[0];
-        const frame = framesStore[frameUrl];
-        // Recycle frames with the same aspect ratio
-        return `FRAME-${
-          frame?.frameInfo?.image?.aspectRatio || "1.91.1"
-        }-${fromMeString}`;
-      } else if (
-        (isContentType("attachment", item.contentType) ||
-          isContentType("remoteAttachment", item.contentType)) &&
-        item.converseMetadata?.attachment?.size?.height &&
-        item.converseMetadata?.attachment?.size?.width
-      ) {
-        const aspectRatio = (
-          item.converseMetadata.attachment.size.width /
-          item.converseMetadata.attachment.size.height
-        ).toFixed(2);
-        return `ATTACHMENT-${aspectRatio}-${fromMeString}`;
-      } else {
-        return `${item.contentType}-${fromMeString}`;
-      }
-    },
-    [framesStore]
-  );
+  const itemType = getItemType(framesStore);
 
   const handleOnLayout = useCallback(() => {
     setTimeout(() => {
@@ -414,12 +433,12 @@ export default function Chat({ readOnly = false }: { readOnly?: boolean }) {
             }
             inverted
             keyExtractor={keyExtractor}
-            getItemType={getItemType}
+            getItemType={itemType}
             keyboardShouldPersistTaps="handled"
             estimatedItemSize={80}
             // Size glitch on Android
-            showsVerticalScrollIndicator={!readOnly && Platform.OS === "ios"}
-            pointerEvents={readOnly ? "none" : "auto"}
+            showsVerticalScrollIndicator={Platform.OS === "ios"}
+            pointerEvents="auto"
             ListFooterComponent={ListFooterComponent}
           />
         )}
@@ -429,10 +448,9 @@ export default function Chat({ readOnly = false }: { readOnly?: boolean }) {
         {showPlaceholder && conversation?.isGroup && (
           <GroupChatPlaceholder messagesCount={listArray.length} />
         )}
-        {!readOnly &&
-          (conversation?.isGroup ? <GroupConsentPopup /> : <ConsentPopup />)}
+        {conversation?.isGroup ? <GroupConsentPopup /> : <ConsentPopup />}
       </Animated.View>
-      {!readOnly && showChatInput && (
+      {showChatInput && (
         <>
           <ReanimatedView
             style={[
@@ -460,6 +478,113 @@ export default function Chat({ readOnly = false }: { readOnly?: boolean }) {
   );
 }
 
+// Lightweight chat preview component used for longpress on chat
+// limited to the last 20 messages
+export function ChatPreview() {
+  const conversation = useConversationContext("conversation");
+  const isBlockedPeer = useConversationContext("isBlockedPeer");
+  const onReadyToFocus = useConversationContext("onReadyToFocus");
+
+  const xmtpAddress = useCurrentAccount() as string;
+  const peerSocials = usePeerSocials();
+
+  const colorScheme = useColorScheme();
+  const styles = useStyles();
+  const messageAttachmentsLength = useChatStore(
+    useShallow((s) => Object.keys(s.messageAttachments).length)
+  );
+
+  const listArray = useMemo(
+    // Get only the last 20 messages for performance in preview
+    () => getListArray(xmtpAddress, conversation, 20),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      xmtpAddress,
+      conversation,
+      conversation?.lastUpdateAt,
+      messageAttachmentsLength,
+    ]
+  );
+
+  const framesStore = useFramesStore().frames;
+  const showPlaceholder =
+    listArray.length === 0 || isBlockedPeer || !conversation;
+  const renderItem = useRenderItem(
+    xmtpAddress,
+    conversation,
+    framesStore,
+    colorScheme
+  );
+  const keyExtractor = useCallback((item: MessageToDisplay) => item.id, []);
+
+  // The first message was really buggy on iOS & Android and this is due to FlashList
+  // so we keep FlatList for new convos and switch to FlashList for bigger convos
+  // that need great perf.
+  const conversationNotPendingRef = useRef(
+    conversation && !conversation.pending
+  );
+  const AnimatedListView =
+    conversationNotPendingRef.current && Platform.OS !== "web"
+      ? ReanimatedFlashList
+      : ReanimatedFlatList;
+
+  const messageListRef = useRef<
+    FlatList<MessageToDisplay> | FlashList<MessageToDisplay> | undefined
+  >();
+
+  const itemType = getItemType(framesStore);
+
+  const handleOnLayout = useCallback(() => {
+    setTimeout(() => {
+      onReadyToFocus();
+    }, 50);
+  }, [onReadyToFocus]);
+
+  return (
+    <View
+      style={styles.chatContainer}
+      key={`chat-${conversation?.peerAddress}-${
+        conversation?.context?.conversationId || ""
+      }-${isBlockedPeer}`}
+    >
+      <Animated.View style={styles.chatPreviewContent}>
+        {conversation && listArray.length > 0 && !isBlockedPeer && (
+          <AnimatedListView
+            contentContainerStyle={styles.chat}
+            data={listArray}
+            refreshing={conversation?.pending}
+            extraData={[peerSocials]}
+            renderItem={renderItem}
+            onLayout={handleOnLayout}
+            ref={(r) => {
+              if (r) {
+                messageListRef.current = r;
+              }
+            }}
+            keyboardDismissMode="interactive"
+            automaticallyAdjustContentInsets={false}
+            contentInsetAdjustmentBehavior="never"
+            estimatedListSize={Dimensions.get("screen")}
+            inverted
+            keyExtractor={keyExtractor}
+            getItemType={itemType}
+            keyboardShouldPersistTaps="handled"
+            estimatedItemSize={80}
+            showsVerticalScrollIndicator={false}
+            pointerEvents="none"
+          />
+        )}
+        {showPlaceholder && !conversation?.isGroup && (
+          <ChatPlaceholder messagesCount={listArray.length} />
+        )}
+        {showPlaceholder && conversation?.isGroup && (
+          <GroupChatPlaceholder messagesCount={listArray.length} />
+        )}
+      </Animated.View>
+    </View>
+  );
+}
+
 const useStyles = () => {
   const colorScheme = useColorScheme();
   return StyleSheet.create({
@@ -471,6 +596,11 @@ const useStyles = () => {
     chatContent: {
       backgroundColor: backgroundColor(colorScheme),
       flex: 1,
+    },
+    chatPreviewContent: {
+      backgroundColor: backgroundColor(colorScheme),
+      flex: 1,
+      paddingBottom: 0,
     },
     chat: {
       backgroundColor: backgroundColor(colorScheme),

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -479,7 +479,6 @@ export function Chat() {
 }
 
 // Lightweight chat preview component used for longpress on chat
-// limited to the last 20 messages
 export function ChatPreview() {
   const conversation = useConversationContext("conversation");
   const isBlockedPeer = useConversationContext("isBlockedPeer");

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -66,13 +66,18 @@ const usePeerSocials = () => {
   return peerSocials;
 };
 
-const useRenderItem = (
-  xmtpAddress: string,
-  conversation: any,
-  framesStore: any,
-  colorScheme: any
-) =>
-  useCallback(
+const useRenderItem = ({
+  xmtpAddress,
+  conversation,
+  framesStore,
+  colorScheme,
+}: {
+  xmtpAddress: string;
+  conversation: any;
+  framesStore: any;
+  colorScheme: any;
+}) => {
+  return useCallback(
     ({ item }: { item: MessageToDisplay }) => {
       return (
         <CachedChatMessage
@@ -86,6 +91,7 @@ const useRenderItem = (
     },
     [colorScheme, xmtpAddress, conversation?.isGroup, framesStore]
   );
+};
 
 const getItemType = (framesStore: any) => (item: MessageToDisplay) => {
   const fromMeString = item.fromMe ? "fromMe" : "notFromMe";
@@ -255,12 +261,16 @@ const useAnimatedListView = (
   }, [conversation]);
 };
 
-const useIsShowingPlaceholder = (
-  listArray: MessageToDisplay[],
-  isBlockedPeer: boolean,
-  conversation: XmtpConversationWithUpdate | undefined
-): boolean => {
-  return listArray.length === 0 || isBlockedPeer || !conversation;
+const useIsShowingPlaceholder = ({
+  messages,
+  isBlockedPeer,
+  conversation,
+}: {
+  messages: MessageToDisplay[];
+  isBlockedPeer: boolean;
+  conversation: XmtpConversationWithUpdate | undefined;
+}): boolean => {
+  return messages.length === 0 || isBlockedPeer || !conversation;
 };
 
 export function Chat() {
@@ -365,17 +375,20 @@ export function Chat() {
   ]);
 
   const framesStore = useFramesStore().frames;
-  const showPlaceholder = useIsShowingPlaceholder(
-    listArray,
+
+  const showPlaceholder = useIsShowingPlaceholder({
+    messages: listArray,
     isBlockedPeer,
-    conversation
-  );
-  const renderItem = useRenderItem(
+    conversation,
+  });
+
+  const renderItem = useRenderItem({
     xmtpAddress,
     conversation,
     framesStore,
-    colorScheme
-  );
+    colorScheme,
+  });
+
   const keyExtractor = useCallback((item: MessageToDisplay) => item.id, []);
 
   const messageListRef = useRef<
@@ -520,17 +533,20 @@ export function ChatPreview() {
   );
 
   const framesStore = useFramesStore().frames;
-  const showPlaceholder = useIsShowingPlaceholder(
-    listArray,
+
+  const showPlaceholder = useIsShowingPlaceholder({
+    messages: listArray,
     isBlockedPeer,
-    conversation
-  );
-  const renderItem = useRenderItem(
+    conversation,
+  });
+
+  const renderItem = useRenderItem({
     xmtpAddress,
     conversation,
     framesStore,
-    colorScheme
-  );
+    colorScheme,
+  });
+
   const keyExtractor = useCallback((item: MessageToDisplay) => item.id, []);
 
   const messageListRef = useRef<

--- a/screens/Conversation.tsx
+++ b/screens/Conversation.tsx
@@ -17,7 +17,7 @@ import { Platform, StyleSheet, useColorScheme, View } from "react-native";
 import { gestureHandlerRootHOC } from "react-native-gesture-handler";
 
 import { NavigationParamList } from "./Navigation/Navigation";
-import ConverseChat from "../components/Chat/Chat";
+import { Chat } from "../components/Chat/Chat";
 import ConversationTitle from "../components/Conversation/ConversationTitle";
 import { EmojiPicker } from "../containers/EmojiPicker";
 import {
@@ -303,7 +303,7 @@ const Conversation = ({
             tagsFetchedOnceForMessage,
           }}
         >
-          <ConverseChat />
+          <Chat />
         </ConversationContext.Provider>
       ) : (
         <View style={styles.filler} />

--- a/screens/ConversationReadOnly.tsx
+++ b/screens/ConversationReadOnly.tsx
@@ -1,4 +1,4 @@
-import ConverseChat from "@components/Chat/Chat";
+import { ChatPreview } from "@components/Chat/Chat";
 import { EmojiPicker } from "@containers/EmojiPicker";
 import {
   currentAccount,
@@ -32,17 +32,10 @@ export const ConversationReadOnly: React.FC<{
     {}
   );
 
-  const {
-    conversations,
-    conversationsMapping,
-    setConversationMessageDraft,
-    setConversationMediaPreview,
-  } = useChatStore(
+  const { conversations, conversationsMapping } = useChatStore(
     useSelect([
       "conversations",
       "conversationsMapping",
-      "setConversationMessageDraft",
-      "setConversationMediaPreview",
       "lastUpdateAt", // Added even if unused to trigger a rerender
     ])
   );
@@ -137,22 +130,6 @@ export const ConversationReadOnly: React.FC<{
     }
   }, [conversation]);
 
-  const onLeaveScreen = useCallback(async () => {
-    if (!conversation) return;
-
-    useChatStore.getState().setOpenedConversationTopic(null);
-    if (textInputRef.current) {
-      setConversationMessageDraft(
-        conversation.topic,
-        textInputRef.current.currentValue
-      );
-    }
-    setConversationMediaPreview(
-      conversation.topic,
-      mediaPreviewRef.current || null
-    );
-  }, [conversation, setConversationMessageDraft, setConversationMediaPreview]);
-
   return (
     <View style={styles.container} key={`conversation-${colorScheme}`}>
       {conversationTopic ? (
@@ -172,7 +149,7 @@ export const ConversationReadOnly: React.FC<{
             tagsFetchedOnceForMessage,
           }}
         >
-          <ConverseChat readOnly />
+          <ChatPreview />
         </ConversationContext.Provider>
       ) : (
         <View style={styles.filler} />


### PR DESCRIPTION
Refactor Chat component and optimize message handling for chat preview (long press on chat > auxiliary preview)

- Remove the `readOnly` props in the chat component, and create a dedicated, more lightweight `<ChatPreview />` component instead
- Extract `usePeerSocials`,  `renderItem` and `getItemType`
- Add optional `lastMessages` parameter in `getListArray` to limit the number of returned messages in `<ChatPreview />`
- Remove `readOnly` prop from `Chat` component, simplifying logic for padding and focus states
- Replace `ConverseChat` with the newly refactored `Chat` component
- Remove default export
- Remove unused code in `screens/ConversationReadOnly.tsx` (onLeaveScreen)

Linked to: https://github.com/ephemeraHQ/converse-app/pull/819#issuecomment-2379231954