### PR TITLE
Noe/revoke from UI

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -4,7 +4,7 @@ import {
   itemSeparatorColor,
   tertiaryBackgroundColor,
 } from "@styles/colors";
-import { getCleanAddress } from "@utils/eth";
+import { getCleanAddress } from "@utils/evm/address";
 import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import {

--- a/components/Chat/Frame/FramePreview.tsx
+++ b/components/Chat/Frame/FramePreview.tsx
@@ -1,5 +1,6 @@
 import logger from "@utils/logger";
 import { FrameActionInputs } from "@xmtp/frames-client";
+import { ethers } from "ethers";
 import { Image } from "expo-image";
 import * as Linking from "expo-linking";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -12,7 +13,7 @@ import config from "../../../config";
 import { useCurrentAccount } from "../../../data/store/accountsStore";
 import { cacheForMedia, fetchAndCacheMedia } from "../../../utils/cache/cache";
 import { useConversationContext } from "../../../utils/conversation";
-import { useExternalProvider } from "../../../utils/evm/external";
+import { useExternalSigner } from "../../../utils/evm/external";
 import {
   FrameButtonType,
   FrameToDisplay,
@@ -57,7 +58,7 @@ export default function FramePreview({
   const messageId = useRef(message.id);
   const fetchingInitialForMessageId = useRef(undefined as undefined | string);
 
-  const { getExternalProvider } = useExternalProvider();
+  const { getExternalSigner } = useExternalSigner();
 
   // Components are recycled, let's fix when stuff changes
   if (message.id !== messageId.current) {
@@ -196,15 +197,15 @@ export default function FramePreview({
               throw new Error("Transaction frames not supported yet");
             }
             // For tx, we get the tx data from target, then trigger it, then do a POST action
-            const externalProvider = await getExternalProvider();
-            if (!externalProvider)
-              throw new Error("Could not get an external wallet provider");
+            const externalSigner = await getExternalSigner();
+            if (!externalSigner || !externalSigner.provider)
+              throw new Error("Could not get an external signer");
 
             const { buttonPostUrl, txHash } = await handleTxAction(
               frame,
               button,
               payload,
-              externalProvider
+              externalSigner.provider as ethers.providers.Web3Provider
             );
 
             payload.untrustedData.transactionId = txHash;
@@ -281,7 +282,7 @@ export default function FramePreview({
       conversation,
       frame,
       frameTextInputValue,
-      getExternalProvider,
+      getExternalSigner,
       initialFrame.url,
       message.topic,
       setFrameTextInputFocused,

--- a/components/Drawer.tsx
+++ b/components/Drawer.tsx
@@ -15,6 +15,7 @@ import {
   useColorScheme,
   useWindowDimensions,
   View,
+  ViewStyle,
 } from "react-native";
 import {
   Gesture,
@@ -40,7 +41,7 @@ export interface DrawerProps {
   visible: boolean;
   children: React.ReactNode;
   onClose?: () => void;
-  style?: any;
+  style?: ViewStyle;
 }
 
 export const DrawerContext = React.createContext<{

--- a/components/Drawer.tsx
+++ b/components/Drawer.tsx
@@ -40,6 +40,7 @@ export interface DrawerProps {
   visible: boolean;
   children: React.ReactNode;
   onClose?: () => void;
+  style?: any;
 }
 
 export const DrawerContext = React.createContext<{
@@ -57,7 +58,7 @@ export interface DrawerRef {
 }
 
 export const Drawer = forwardRef<DrawerRef, DrawerProps>(function Drawer(
-  { children, visible, onClose },
+  { children, visible, onClose, style },
   ref
 ) {
   const styles = useStyles();
@@ -171,7 +172,7 @@ export const Drawer = forwardRef<DrawerRef, DrawerProps>(function Drawer(
           </TouchableWithoutFeedback>
           <GestureDetector gesture={composed}>
             <ReanimatedView
-              style={[styles.trayContainer, animtedStyle]}
+              style={[styles.trayContainer, animtedStyle, style]}
               layout={LinearTransition.springify()}
             >
               <View style={styles.handle} />

--- a/components/ExternalWalletPicker.tsx
+++ b/components/ExternalWalletPicker.tsx
@@ -1,0 +1,96 @@
+import { translate } from "@i18n";
+import {
+  backgroundColor,
+  itemSeparatorColor,
+  tertiaryBackgroundColor,
+  textPrimaryColor,
+} from "@styles/colors";
+import { PictoSizes } from "@styles/sizes";
+import { Image } from "expo-image";
+import { useCallback, useRef, useState } from "react";
+import { StyleSheet, Text, useColorScheme, View } from "react-native";
+
+import Button from "./Button/Button";
+import { Drawer, DrawerRef } from "./Drawer";
+import { useInstalledWallets } from "./Onboarding/supportedWallets";
+import Picto from "./Picto/Picto";
+
+export default function ExternalWalletPicker() {
+  const styles = useStyles();
+  const colorScheme = useColorScheme();
+  const drawerRef = useRef<DrawerRef>(null);
+  const [visible, setVisible] = useState(true);
+  const closeMenu = useCallback(() => {
+    setVisible(false);
+  }, []);
+  const wallets = useInstalledWallets();
+  return (
+    <Drawer
+      visible={visible}
+      onClose={closeMenu}
+      ref={drawerRef}
+      style={styles.drawer}
+    >
+      <View>
+        {wallets.map((w) => (
+          <View key={w.name} style={styles.wallet}>
+            <Image source={{ uri: w.iconURL }} style={styles.walletIcon} />
+            <Text style={styles.walletName}>{w.name}</Text>
+            <Picto
+              picto="chevron.right"
+              style={styles.chevron}
+              size={PictoSizes.externalWallet}
+              color={textPrimaryColor(colorScheme)}
+              weight="semibold"
+            />
+          </View>
+        ))}
+        <Button
+          variant="primary"
+          title={translate("cancel")}
+          style={styles.cta}
+          onPress={() => drawerRef.current?.closeDrawer(() => {})}
+        />
+      </View>
+    </Drawer>
+  );
+}
+
+const useStyles = () => {
+  const colorScheme = useColorScheme();
+  return StyleSheet.create({
+    drawer: {
+      backgroundColor: tertiaryBackgroundColor(colorScheme),
+    },
+    cta: {
+      marginHorizontal: 0,
+      marginTop: 20,
+      marginBottom: 10,
+    },
+    wallet: {
+      flex: 1,
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: backgroundColor(colorScheme),
+      borderWidth: 1,
+      borderColor: itemSeparatorColor(colorScheme),
+      borderRadius: 12,
+      padding: 8,
+      marginVertical: 4,
+    },
+    walletName: {
+      fontSize: 14,
+      fontWeight: "500",
+      marginLeft: 8,
+    },
+    walletIcon: {
+      width: 40,
+      height: 40,
+      borderRadius: 8,
+    },
+    chevron: {
+      marginLeft: "auto",
+      marginRight: 12,
+    },
+  });
+};

--- a/components/ExternalWalletPicker.tsx
+++ b/components/ExternalWalletPicker.tsx
@@ -23,12 +23,12 @@ import { Account, createWallet, Wallet } from "thirdweb/wallets";
 
 import Button from "./Button/Button";
 import { Drawer, DrawerRef } from "./Drawer";
+import config from "../config";
 import {
   InstalledWallet,
   useInstalledWallets,
 } from "./Onboarding/supportedWallets";
 import Picto from "./Picto/Picto";
-import config from "../config";
 
 export default function ExternalWalletPicker() {
   const styles = useStyles();
@@ -97,8 +97,8 @@ export default function ExternalWalletPicker() {
           account: undefined,
         });
       }
-      await waitUntilAppActive(500);
       setVisible(false);
+      await waitUntilAppActive(500);
     },
     []
   );
@@ -119,7 +119,9 @@ export default function ExternalWalletPicker() {
       );
     };
   }, [displayExternalWalletPicker]);
+
   const wallets = useInstalledWallets();
+
   return (
     <Drawer
       visible={visible}

--- a/components/ExternalWalletPicker.tsx
+++ b/components/ExternalWalletPicker.tsx
@@ -150,7 +150,7 @@ export default function ExternalWalletPicker() {
             />
           </TouchableOpacity>
         ))}
-        {wallets.length === 0 && <Text>No wallet detected</Text>}
+        {wallets.length === 0 && <Text>{translate("no_wallet_detected")}</Text>}
         <Button
           variant="primary"
           title={translate("cancel")}
@@ -172,9 +172,11 @@ const useStyles = () => {
     title: {
       fontSize: 16,
       fontWeight: "700",
+      color: textPrimaryColor(colorScheme),
     },
     subtitle: {
       fontSize: 14,
+      color: textPrimaryColor(colorScheme),
     },
     separator: {
       marginTop: 13,
@@ -200,6 +202,7 @@ const useStyles = () => {
       fontSize: 14,
       fontWeight: "500",
       marginLeft: 8,
+      color: textPrimaryColor(colorScheme),
     },
     walletIcon: {
       width: 40,

--- a/components/Onboarding/WalletSelector.tsx
+++ b/components/Onboarding/WalletSelector.tsx
@@ -35,21 +35,15 @@ import {
 } from "../TableView/TableViewImage";
 
 export default function WalletSelector() {
-  const {
-    setConnectionMethod,
-    setSigner,
-    setLoading,
-    addingNewAccount,
-    setAddingNewAccount,
-  } = useOnboardingStore(
-    useSelect([
-      "setConnectionMethod",
-      "setSigner",
-      "setLoading",
-      "addingNewAccount",
-      "setAddingNewAccount",
-    ])
-  );
+  const { setConnectionMethod, setSigner, setLoading, setAddingNewAccount } =
+    useOnboardingStore(
+      useSelect([
+        "setConnectionMethod",
+        "setSigner",
+        "setLoading",
+        "setAddingNewAccount",
+      ])
+    );
   const colorScheme = useColorScheme();
   const { connect: thirdwebConnect } = useConnect();
   const setActiveWallet = useSetActiveWallet();

--- a/components/Onboarding/supportedWallets.ts
+++ b/components/Onboarding/supportedWallets.ts
@@ -1,4 +1,5 @@
 import * as Linking from "expo-linking";
+import { useEffect, useState } from "react";
 import { WalletId } from "thirdweb/wallets";
 
 import { isDesktop } from "../../utils/device";
@@ -160,4 +161,12 @@ export const getInstalledWallets = async (
   installedWallets = wallets;
   hasCheckedInstalled = true;
   return installedWallets;
+};
+
+export const useInstalledWallets = () => {
+  const [wallets, setWallets] = useState(installedWallets);
+  useEffect(() => {
+    getInstalledWallets(true).then(setWallets);
+  }, []);
+  return wallets;
 };

--- a/components/Picto/Picto.tsx
+++ b/components/Picto/Picto.tsx
@@ -62,6 +62,7 @@ type Props = {
   style?: StyleProp<ViewStyle>;
   color?: ColorValue;
   size?: number;
+  weight?: string;
 };
 
 const pictoMapping: {

--- a/data/helpers/conversations/pendingConversations.ts
+++ b/data/helpers/conversations/pendingConversations.ts
@@ -5,7 +5,7 @@ import { In } from "typeorm/browser";
 import { v4 as uuidv4 } from "uuid";
 
 import { saveConversations } from "./upsertConversations";
-import { getCleanAddress } from "../../../utils/eth";
+import { getCleanAddress } from "../../../utils/evm/address";
 import { getRepository } from "../../db";
 import { Conversation } from "../../db/entities/conversationEntity";
 import { upsertRepository } from "../../db/upsert";

--- a/data/helpers/profiles/profilesUpdate.ts
+++ b/data/helpers/profiles/profilesUpdate.ts
@@ -1,15 +1,10 @@
-import { getCleanAddress } from "@utils/eth";
+import { getCleanAddress } from "@utils/evm/address";
 
 import { getProfilesForAddresses } from "../../../utils/api";
 import { getProfile } from "../../../utils/profile";
 import { getChatStore, getProfilesStore } from "../../store/accountsStore";
 import { XmtpConversation } from "../../store/chatStore";
 import { ProfileSocials } from "../../store/profilesStore";
-
-type ConversationHandlesUpdate = {
-  conversation: XmtpConversation;
-  updated: boolean;
-};
 
 export const updateProfilesForConvos = async (
   account: string,

--- a/data/store/inboxIdStore.ts
+++ b/data/store/inboxIdStore.ts
@@ -1,4 +1,4 @@
-import { getCleanAddress } from "@utils/eth";
+import { getCleanAddress } from "@utils/evm/address";
 import { Member } from "@xmtp/react-native-sdk";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";

--- a/data/store/profilesStore.ts
+++ b/data/store/profilesStore.ts
@@ -1,4 +1,4 @@
-import { getCleanAddress } from "@utils/eth";
+import { getCleanAddress } from "@utils/evm/address";
 import logger from "@utils/logger";
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";

--- a/data/updates/001-setConsent.ts
+++ b/data/updates/001-setConsent.ts
@@ -3,7 +3,7 @@ import { ConsentListEntry } from "@xmtp/react-native-sdk";
 
 import { getChatStore, getSettingsStore } from "../../data/store/accountsStore";
 import { deletePeersFromDb, getPeersStatus } from "../../utils/api";
-import { getCleanAddress } from "../../utils/eth";
+import { getCleanAddress } from "../../utils/evm/address";
 import { getXmtpClient } from "../../utils/xmtpRN/sync";
 import { SettingsStoreType } from "../store/settingsStore";
 

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -295,16 +295,16 @@ const en = {
   no_wallet_detected: "No wallet detected",
 
   // Revocation
-  current_installation_revoked: "Installation revoked",
+  current_installation_revoked: "Logged out",
   current_installation_revoked_description:
-    "The current installation has been revoked, you will now get logged out and group chats will be deleted",
-  other_installations_count: "You have {{count}} other installations",
-  revoke_description: "Can we revoke those installations now?",
+    "You have been logged out of your account. Your group chats will be deleted from this device.",
+  other_installations_count: "You have {{count}} active logins",
+  revoke_description: "Would you like to log out from all other sessions?",
   revoke_done_title: "Done",
-  revoke_done_description: "{{count}} other installations successfully revoked",
-  revoke_empty: "You have no other installations",
-  revoke_others_cta: "Revoke other installations",
-  revoke_wallet_picker_title: "Revoke other installations",
+  revoke_done_description: "Logged out of {{count}} sessions",
+  revoke_empty: "You have no other active sessions",
+  revoke_others_cta: "Log out others",
+  revoke_wallet_picker_title: "Log out others",
   revoke_wallet_picker_description:
     "Connect the wallet associated with your XMTP account: {{wallet}}",
 

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -301,6 +301,9 @@ const en = {
   revoke_done_description: "{{count}} other installations successfully revoked",
   revoke_empty: "You have no other installations",
   revoke_others_cta: "Revoke other installations",
+  revoke_wallet_picker_title: "Revoke other installations",
+  revoke_wallet_picker_description:
+    "Connect the wallet associated with your XMTP account: {{wallet}}",
 
   // Emoji Picker
   search_emojis: "Search emojis",

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -230,7 +230,7 @@ const en = {
   security: "SECURITY",
   xmtp_wrong_signer: "Wrong wallet",
   xmtp_wrong_signer_description:
-    "Please connect the wallet that owns this XMTP account",
+    "Linked wallet does not own that XMTP identity. We unlinked it, please try again.",
 
   // Context Menu
   reply: "Reply",

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -228,6 +228,9 @@ const en = {
   youre_the_og: "YOU'RE THE OG",
   app_version: "APP VERSION",
   security: "SECURITY",
+  xmtp_wrong_signer: "Wrong wallet",
+  xmtp_wrong_signer_description:
+    "Please connect the wallet that owns this XMTP account",
 
   // Context Menu
   reply: "Reply",
@@ -293,7 +296,10 @@ const en = {
   current_installation_revoked_description:
     "The current installation has been revoked, you will now get logged out and group chats will be deleted",
   other_installations_count: "You have {{count}} other installations",
-  temporary_revoke_description: "Can we revoke those installations now?",
+  revoke_description: "Can we revoke those installations now?",
+  revoke_done_title: "Done",
+  revoke_done_description: "{{count}} other installations successfully revoked",
+  revoke_empty: "You have no other installations",
 
   // Emoji Picker
   search_emojis: "Search emojis",

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -291,6 +291,9 @@ const en = {
   deny: "Deny",
   approve_member_to_this_group: "Approve {{name}} to this group",
 
+  // Wallet selector
+  no_wallet_detected: "No wallet detected",
+
   // Revocation
   current_installation_revoked: "Installation revoked",
   current_installation_revoked_description:

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -300,6 +300,7 @@ const en = {
   revoke_done_title: "Done",
   revoke_done_description: "{{count}} other installations successfully revoked",
   revoke_empty: "You have no other installations",
+  revoke_others_cta: "Revoke other installations",
 
   // Emoji Picker
   search_emojis: "Search emojis",

--- a/queries/useGroupMembersQuery.ts
+++ b/queries/useGroupMembersQuery.ts
@@ -3,7 +3,7 @@ import {
   SetDataOptions,
   useQuery,
 } from "@tanstack/react-query";
-import { getCleanAddress } from "@utils/eth";
+import { getCleanAddress } from "@utils/evm/address";
 import { Member } from "@xmtp/react-native-sdk";
 import { InboxId } from "@xmtp/react-native-sdk/build/lib/Client";
 

--- a/queries/useGroupQuery.ts
+++ b/queries/useGroupQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getCleanAddress } from "@utils/eth";
+import { getCleanAddress } from "@utils/evm/address";
 import { getGroupIdFromTopic, isGroupTopic } from "@utils/groupUtils/groupId";
 import {
   ConverseXmtpClientType,

--- a/screens/Accounts/Accounts.tsx
+++ b/screens/Accounts/Accounts.tsx
@@ -5,7 +5,6 @@ import {
   primaryColor,
   textSecondaryColor,
 } from "@styles/colors";
-import logger from "@utils/logger";
 import { ScrollView, StyleSheet, View, useColorScheme } from "react-native";
 
 import AccountSettingsButton from "../../components/AccountSettingsButton";
@@ -17,7 +16,6 @@ import {
   useErroredAccountsMap,
 } from "../../data/store/accountsStore";
 import { useOnboardingStore } from "../../data/store/onboardingStore";
-import { useDisconnectWallet } from "../../utils/logout/wallet";
 import { shortAddress, useAccountsProfiles } from "../../utils/str";
 import { NavigationParamList } from "../Navigation/Navigation";
 
@@ -32,7 +30,6 @@ export default function Accounts({
   const setCurrentAccount = useAccountsStore((s) => s.setCurrentAccount);
   const setAddingNewAccount = useOnboardingStore((s) => s.setAddingNewAccount);
   const colorScheme = useColorScheme();
-  const disconnectWallet = useDisconnectWallet();
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
@@ -70,12 +67,7 @@ export default function Accounts({
             id: "add",
             title: "Add an account",
             titleColor: primaryColor(colorScheme),
-            action: async () => {
-              try {
-                await disconnectWallet();
-              } catch (e) {
-                logger.error(e);
-              }
+            action: () => {
               setAddingNewAccount(true);
             },
           },

--- a/screens/Accounts/AccountsAndroid.tsx
+++ b/screens/Accounts/AccountsAndroid.tsx
@@ -1,7 +1,6 @@
 import { NavigationProp } from "@react-navigation/native";
 import { backgroundColor, clickedItemBackgroundColor } from "@styles/colors";
 import { PictoSizes } from "@styles/sizes";
-import logger from "@utils/logger";
 import { Dimensions, Platform, StyleSheet, useColorScheme } from "react-native";
 import { Drawer } from "react-native-paper";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -15,7 +14,6 @@ import {
 import { useOnboardingStore } from "../../data/store/onboardingStore";
 import { useSelect } from "../../data/store/storeHelpers";
 import { converseEventEmitter } from "../../utils/events";
-import { useDisconnectWallet } from "../../utils/logout/wallet";
 import { shortAddress, useAccountsProfiles } from "../../utils/str";
 
 type Props = {
@@ -27,7 +25,6 @@ export default function AccountsAndroid({ navigation }: Props) {
   const accounts = useAccountsList();
   const accountsProfiles = useAccountsProfiles();
 
-  const disconnectWallet = useDisconnectWallet();
   const { currentAccount, setCurrentAccount } = useAccountsStore(
     useSelect(["currentAccount", "setCurrentAccount"])
   );
@@ -85,12 +82,7 @@ export default function AccountsAndroid({ navigation }: Props) {
         icon={({ color }) => (
           <Picto picto="plus" size={PictoSizes.navItem} color={color} />
         )}
-        onPress={async () => {
-          try {
-            await disconnectWallet();
-          } catch (e) {
-            logger.error(e);
-          }
+        onPress={() => {
           setAddingNewAccount(true);
         }}
         rippleColor={clickedItemBackgroundColor(colorScheme)}

--- a/screens/Main.tsx
+++ b/screens/Main.tsx
@@ -1,3 +1,4 @@
+import ExternalWalletPicker from "@components/ExternalWalletPicker";
 import UserProfile from "@components/Onboarding/UserProfile";
 import { backgroundColor } from "@styles/colors";
 import { getProfile } from "@utils/profile";
@@ -148,6 +149,7 @@ export default function Main() {
     <>
       {mainHeaders}
       {screenToShow}
+      <ExternalWalletPicker />
     </>
   );
 }

--- a/screens/Main.tsx
+++ b/screens/Main.tsx
@@ -1,6 +1,7 @@
 import ExternalWalletPicker from "@components/ExternalWalletPicker";
 import UserProfile from "@components/Onboarding/UserProfile";
 import { backgroundColor } from "@styles/colors";
+import { useAutoConnectExternalWallet } from "@utils/evm/external";
 import { getProfile } from "@utils/profile";
 import { useCheckCurrentInstallation } from "@utils/xmtpRN/client";
 import { StatusBar } from "expo-status-bar";
@@ -38,6 +39,7 @@ export default function Main() {
   usePrivyAccessToken();
   useAddressBookStateHandler();
   useCheckCurrentInstallation();
+  useAutoConnectExternalWallet();
   const colorScheme = useColorScheme();
   const userAddress = useCurrentAccount();
   const socials = useProfilesStore((s) =>

--- a/screens/NewConversation/NewConversation.tsx
+++ b/screens/NewConversation/NewConversation.tsx
@@ -43,7 +43,7 @@ import {
   getAddressForPeer,
   getCleanAddress,
   isSupportedPeer,
-} from "../../utils/eth";
+} from "../../utils/evm/address";
 import { navigate } from "../../utils/navigation";
 import { isEmptyObject } from "../../utils/objects";
 import { getPreferredName } from "../../utils/profile";

--- a/screens/Onboarding.tsx
+++ b/screens/Onboarding.tsx
@@ -124,13 +124,7 @@ export default function Onboarding() {
       });
       if (!base64Key) return;
       await connectWithBase64Key(base64Key, async () => {
-        logoutAccount(
-          await signer.getAddress(),
-          false,
-          true,
-          () => {},
-          () => {}
-        );
+        logoutAccount(await signer.getAddress(), false, true, () => {});
       });
     } catch (e) {
       initiatingClientFor.current = undefined;

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -14,10 +14,10 @@ import {
   textSecondaryColor,
 } from "@styles/colors";
 import { PictoSizes } from "@styles/sizes";
-import { waitUntilAppActive } from "@utils/appState";
 import { useExternalSigner } from "@utils/evm/external";
 import { usePrivySigner } from "@utils/evm/privy";
 import { memberCanUpdateGroup } from "@utils/groupUtils/memberCanUpdateGroup";
+import { shortAddress } from "@utils/str";
 import { ConverseXmtpClientType } from "@utils/xmtpRN/client";
 import {
   getOtherInstallations,
@@ -82,6 +82,7 @@ import {
   getPreferredAvatar,
   getPreferredName,
   getProfile,
+  getPreferredUsername,
 } from "../utils/profile";
 import { getIPFSAssetURI } from "../utils/thirdweb";
 import { refreshBalanceForAccount } from "../utils/wallet";
@@ -805,7 +806,18 @@ export default function ProfileScreen({
                   }
 
                   if (!signer) {
-                    signer = await getExternalSigner();
+                    const socials =
+                      useProfilesStore.getState().profiles[client.address]
+                        ?.socials;
+                    signer = await getExternalSigner(
+                      translate("revoke_wallet_picker_title"),
+                      translate("revoke_wallet_picker_description", {
+                        wallet:
+                          getPreferredUsername(socials) ||
+                          shortAddress(client.address),
+                      })
+                    );
+                    if (!signer) return;
                     const externalAddress = await signer.getAddress();
                     if (
                       externalAddress.toLowerCase() !==
@@ -819,8 +831,6 @@ export default function ProfileScreen({
                       return;
                     }
                   }
-
-                  await waitUntilAppActive(500);
                   const revoked = await revokeOtherInstallations(
                     signer,
                     client,

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -759,6 +759,17 @@ export default function ProfileScreen({
                     : primaryColor(colorScheme),
               },
               {
+                id: "revokeOtherInstallations",
+                title: "Revoke other installations",
+                titleColor:
+                  Platform.OS === "android"
+                    ? undefined
+                    : primaryColor(colorScheme),
+                action: () => {
+                  console.log("YOYOOYUO");
+                },
+              },
+              {
                 id: "delete",
                 title: "Disconnect this account",
                 titleColor:

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -770,7 +770,7 @@ export default function ProfileScreen({
               },
               {
                 id: "revokeOtherInstallations",
-                title: "Revoke other installations",
+                title: translate("revoke_others_cta"),
                 titleColor:
                   Platform.OS === "android"
                     ? undefined

--- a/styles/sizes/index.ts
+++ b/styles/sizes/index.ts
@@ -36,6 +36,7 @@ export enum PictoSizes {
   tableViewImage = Platform.OS === "ios" ? 16 : 24,
   textButton = 15,
   cancelAttachmentButton = 6,
+  externalWallet = 14,
 }
 
 export const BorderRadius = {

--- a/utils/conversation.ts
+++ b/utils/conversation.ts
@@ -9,7 +9,7 @@ import {
   isAttachmentMessage,
   fetchLocalAttachmentUrl,
 } from "./attachment/helpers";
-import { getAddressForPeer } from "./eth";
+import { getAddressForPeer } from "./evm/address";
 import { getGroupIdFromTopic } from "./groupUtils/groupId";
 import logger from "./logger";
 import { subscribeToNotifications } from "./notifications";

--- a/utils/events.ts
+++ b/utils/events.ts
@@ -1,6 +1,7 @@
 import { MessageToDisplay } from "@components/Chat/Message/Message";
 import { MediaPreview } from "@data/store/chatStore";
 import EventEmitter from "eventemitter3";
+import { Account, Wallet } from "thirdweb/wallets";
 
 import { GroupWithCodecsType } from "./xmtpRN/client";
 
@@ -26,6 +27,11 @@ type ConverseEvents = {
     animated?: boolean;
   }) => void;
   toggleSpamRequests: () => void;
+  displayExternalWalletPicker: (title?: string, subtitle?: string) => void;
+  externalWalletPicked: (walletPicked: {
+    wallet: Wallet | undefined;
+    account: Account | undefined;
+  }) => void;
 };
 
 type ShowActionSheetEvents = {
@@ -46,3 +52,13 @@ type Events = ConverseEvents &
   AttachmentMessageProcessedEvents;
 
 export const converseEventEmitter = new EventEmitter<Events>();
+
+export async function waitForConverseEvent<K extends keyof Events>(
+  eventName: K
+): Promise<Parameters<Events[K]>> {
+  return new Promise<Parameters<Events[K]>>((resolve) => {
+    converseEventEmitter.once(eventName, (...args: unknown[]) => {
+      resolve(args as Parameters<Events[K]>);
+    });
+  });
+}

--- a/utils/evm/address.ts
+++ b/utils/evm/address.ts
@@ -1,20 +1,13 @@
-import { pbkdf2 } from "crypto";
-import { ethers } from "ethers";
-import {
-  entropyToMnemonic,
-  getAddress,
-  isAddress,
-  mnemonicToEntropy,
-} from "ethers/lib/utils";
-
 import {
   resolveEnsName,
-  resolveFarcasterUsername,
   resolveUnsDomain,
-} from "./api";
-import { getLensOwner } from "./lens";
-import { isUNSAddress } from "./uns";
-import config from "../config";
+  resolveFarcasterUsername,
+} from "@utils/api";
+import { getLensOwner } from "@utils/lens";
+import { isUNSAddress } from "@utils/uns";
+import { isAddress, getAddress } from "ethers/lib/utils";
+
+import config from "../../config";
 
 export const isSupportedPeer = (peer: string) => {
   const is0x = isAddress(peer.toLowerCase());
@@ -60,21 +53,6 @@ export const getAddressForPeer = async (peer: string) => {
     : peer;
   return resolvedAddress;
 };
-
-export const validateMnemonic = (mnemonic: string) =>
-  entropyToMnemonic(mnemonicToEntropy(mnemonic));
-
-export const getPrivateKeyFromMnemonic = (mnemonic: string): Promise<string> =>
-  new Promise((resolve, reject) => {
-    pbkdf2(mnemonic, "mnemonic", 2048, 64, "sha512", (error, key) => {
-      if (error) return reject(error);
-      const hdnode = ethers.utils.HDNode.fromSeed(key);
-      const path = "m/44'/60'/0'/0/0";
-      const childNode = hdnode.derivePath(path);
-      const privateKey = childNode.privateKey;
-      resolve(privateKey);
-    });
-  });
 
 export const getCleanAddress = (address: string) => {
   const lowercased = address.toLowerCase();

--- a/utils/evm/external.ts
+++ b/utils/evm/external.ts
@@ -8,6 +8,7 @@ import { ethereum } from "thirdweb/chains";
 import {
   useActiveAccount,
   useActiveWallet,
+  useAutoConnect,
   useDisconnect,
   useSetActiveWallet,
 } from "thirdweb/react";
@@ -24,6 +25,9 @@ export const useExternalSigner = () => {
   const activeAccount = useActiveAccount();
   const activeWallet = useActiveWallet();
   const { disconnect } = useDisconnect();
+  useAutoConnect({
+    client: thirdwebClient,
+  });
 
   const getExternalSigner = useCallback(
     async (title?: string, subtitle?: string) => {

--- a/utils/evm/external.ts
+++ b/utils/evm/external.ts
@@ -13,6 +13,10 @@ import {
 } from "thirdweb/react";
 import { Wallet } from "thirdweb/wallets";
 
+/**
+ * External wallet signer (i.e. not Privy)
+ * for XMTP signatures or tx frames
+ */
 export const useExternalSigner = () => {
   const thirdwebSigner = useRef<Signer | undefined>();
   const thirdwebWallet = useRef<Wallet | undefined>();

--- a/utils/evm/external.ts
+++ b/utils/evm/external.ts
@@ -25,9 +25,6 @@ export const useExternalSigner = () => {
   const activeAccount = useActiveAccount();
   const activeWallet = useActiveWallet();
   const { disconnect } = useDisconnect();
-  useAutoConnect({
-    client: thirdwebClient,
-  });
 
   const getExternalSigner = useCallback(
     async (title?: string, subtitle?: string) => {
@@ -71,4 +68,12 @@ export const useExternalSigner = () => {
   }, [activeWallet, disconnect]);
 
   return { getExternalSigner, resetExternalSigner };
+};
+
+export const useAutoConnectExternalWallet = () => {
+  // Keep access to last
+  // thirdweb external wallet
+  useAutoConnect({
+    client: thirdwebClient,
+  });
 };

--- a/utils/evm/external.ts
+++ b/utils/evm/external.ts
@@ -1,10 +1,72 @@
-import { useCallback } from "react";
+import logger from "@utils/logger";
+import { thirdwebClient } from "@utils/thirdweb";
+import { Signer } from "ethers";
+import { useCallback, useRef } from "react";
+import { ethers5Adapter } from "thirdweb/adapters/ethers5";
+import { ethereum } from "thirdweb/chains";
+import {
+  useActiveAccount,
+  useActiveWallet,
+  useDisconnect,
+  useSetActiveWallet,
+} from "thirdweb/react";
+import { Account, createWallet, Wallet } from "thirdweb/wallets";
 
-// @todo => implement to be able to trigger tx from
-// external wallet i.e. not privy
-export const useExternalProvider = () => {
-  const getExternalProvider = useCallback(() => {
-    return undefined;
-  }, []);
-  return { getExternalProvider };
+import config from "../../config";
+
+export const useExternalSigner = () => {
+  const thirdwebSigner = useRef<Signer | undefined>();
+  const thirdwebWallet = useRef<Wallet | undefined>();
+  const setActiveWallet = useSetActiveWallet();
+  const activeAccount = useActiveAccount();
+  const activeWallet = useActiveWallet();
+  const { disconnect } = useDisconnect();
+
+  const getExternalSigner = useCallback(async () => {
+    if (thirdwebSigner.current) return thirdwebSigner.current;
+    if (activeAccount) {
+      thirdwebSigner.current = await ethers5Adapter.signer.toEthers({
+        client: thirdwebClient,
+        chain: ethereum,
+        account: activeAccount,
+      });
+      return thirdwebSigner.current;
+    }
+    const coinbaseWallet = createWallet("com.coinbase.wallet", {
+      appMetadata: config.walletConnectConfig.appMetadata,
+      mobileConfig: {
+        callbackURL: `https://${config.websiteDomain}/coinbase`,
+      },
+    });
+    // Let's first try to autoconnect
+    let account: Account | undefined = undefined;
+    try {
+      account = await coinbaseWallet.autoConnect({ client: thirdwebClient });
+    } catch {
+      account = await coinbaseWallet.connect({ client: thirdwebClient });
+    }
+    setActiveWallet(coinbaseWallet);
+    thirdwebSigner.current = await ethers5Adapter.signer.toEthers({
+      client: thirdwebClient,
+      chain: ethereum,
+      account,
+    });
+    thirdwebWallet.current = coinbaseWallet;
+    return thirdwebSigner.current;
+  }, [activeAccount, setActiveWallet]);
+
+  const resetExternalSigner = useCallback(() => {
+    try {
+      if (activeWallet) {
+        disconnect(activeWallet);
+      }
+      thirdwebWallet.current?.disconnect();
+    } catch (e) {
+      logger.warn(e);
+    }
+    thirdwebWallet.current = undefined;
+    thirdwebSigner.current = undefined;
+  }, [activeWallet, disconnect]);
+
+  return { getExternalSigner, resetExternalSigner };
 };

--- a/utils/evm/external.web.ts
+++ b/utils/evm/external.web.ts
@@ -6,7 +6,7 @@ import {
 import { ethers } from "ethers";
 import { useCallback, useEffect, useRef } from "react";
 
-export const useExternalProvider = () => {
+export const useExternalSigner = () => {
   const { walletProvider } = useWeb3ModalProvider();
 
   const currentWalletProvider = useRef(walletProvider);
@@ -20,9 +20,11 @@ export const useExternalProvider = () => {
     currentWeb3ModalOpen.current = isWeb3ModalOpen;
   }, [isWeb3ModalOpen]);
 
-  const getExternalProvider = useCallback(async () => {
+  const getExternalSigner = useCallback(async () => {
     if (currentWalletProvider.current) {
-      return new ethers.providers.Web3Provider(currentWalletProvider.current);
+      return new ethers.providers.Web3Provider(
+        currentWalletProvider.current
+      ).getSigner();
     }
     await openWeb3Modal();
     while (!currentWeb3ModalOpen.current) {
@@ -39,9 +41,16 @@ export const useExternalProvider = () => {
       i += 1;
     }
     if (currentWalletProvider.current) {
-      return new ethers.providers.Web3Provider(currentWalletProvider.current);
+      return new ethers.providers.Web3Provider(
+        currentWalletProvider.current
+      ).getSigner();
     }
     return undefined;
   }, [openWeb3Modal]);
-  return { getExternalProvider };
+
+  const resetExternalSigner = useCallback(() => {
+    currentWalletProvider.current = undefined;
+  }, []);
+
+  return { getExternalSigner, resetExternalSigner };
 };

--- a/utils/evm/external.web.ts
+++ b/utils/evm/external.web.ts
@@ -54,3 +54,7 @@ export const useExternalSigner = () => {
 
   return { getExternalSigner, resetExternalSigner };
 };
+
+export const useAutoConnectExternalWallet = () => {
+  // Built into web3modal
+};

--- a/utils/evm/mnemonic.ts
+++ b/utils/evm/mnemonic.ts
@@ -1,0 +1,18 @@
+import { pbkdf2 } from "crypto";
+import { ethers } from "ethers";
+import { entropyToMnemonic, mnemonicToEntropy } from "ethers/lib/utils";
+
+export const validateMnemonic = (mnemonic: string) =>
+  entropyToMnemonic(mnemonicToEntropy(mnemonic));
+
+export const getPrivateKeyFromMnemonic = (mnemonic: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    pbkdf2(mnemonic, "mnemonic", 2048, 64, "sha512", (error, key) => {
+      if (error) return reject(error);
+      const hdnode = ethers.utils.HDNode.fromSeed(key);
+      const path = "m/44'/60'/0'/0/0";
+      const childNode = hdnode.derivePath(path);
+      const privateKey = childNode.privateKey;
+      resolve(privateKey);
+    });
+  });

--- a/utils/evm/xmtp.ts
+++ b/utils/evm/xmtp.ts
@@ -1,0 +1,46 @@
+import { useCurrentAccount } from "@data/store/accountsStore";
+import { translate } from "@i18n";
+import { ConverseXmtpClientType } from "@utils/xmtpRN/client";
+import { getXmtpClient } from "@utils/xmtpRN/sync";
+import { useCallback } from "react";
+import { Alert } from "react-native";
+
+import { useExternalSigner } from "./external";
+import { usePrivySigner } from "./privy";
+
+/**
+ * XMTP Signer for XMTP operations like
+ * revoking installations
+ */
+export const useXmtpSigner = () => {
+  const account = useCurrentAccount() as string;
+  const privySigner = usePrivySigner();
+  const { getExternalSigner, resetExternalSigner } = useExternalSigner();
+  const getXmtpSigner = useCallback(
+    async (title?: string, subtitle?: string) => {
+      const client = (await getXmtpClient(account)) as ConverseXmtpClientType;
+
+      if (privySigner) {
+        const privyAddress = await privySigner.getAddress();
+        if (privyAddress.toLowerCase() === client.address.toLowerCase()) {
+          return privySigner;
+        }
+      }
+
+      const externalSigner = await getExternalSigner(title, subtitle);
+      if (!externalSigner) return;
+      const externalAddress = await externalSigner.getAddress();
+      if (externalAddress.toLowerCase() !== client.address.toLowerCase()) {
+        Alert.alert(
+          translate("xmtp_wrong_signer"),
+          translate("xmtp_wrong_signer_description")
+        );
+        resetExternalSigner();
+        return;
+      }
+      return externalSigner;
+    },
+    [account, getExternalSigner, privySigner, resetExternalSigner]
+  );
+  return { getXmtpSigner };
+};

--- a/utils/groupUtils/adminUtils.ts
+++ b/utils/groupUtils/adminUtils.ts
@@ -1,4 +1,4 @@
-import { getCleanAddress } from "@utils/eth";
+import { getCleanAddress } from "@utils/evm/address";
 import { Member } from "@xmtp/react-native-sdk";
 import { InboxId } from "@xmtp/react-native-sdk/build/lib/Client";
 

--- a/utils/groupUtils/sortGroupMembersByAdminStatus.ts
+++ b/utils/groupUtils/sortGroupMembersByAdminStatus.ts
@@ -1,4 +1,4 @@
-import { getCleanAddress } from "@utils/eth";
+import { getCleanAddress } from "@utils/evm/address";
 import { Member } from "@xmtp/react-native-sdk";
 import { InboxId } from "@xmtp/react-native-sdk/build/lib/Client";
 

--- a/utils/logout/index.tsx
+++ b/utils/logout/index.tsx
@@ -5,7 +5,6 @@ import { getInboxId } from "@utils/xmtpRN/signIn";
 import { useCallback } from "react";
 
 import { useDisconnectFromPrivy } from "./privy";
-import { useDisconnectWallet } from "./wallet";
 import { clearConverseDb, getConverseDbPath } from "../../data/db";
 import {
   getAccountsList,
@@ -140,7 +139,6 @@ export const logoutAccount = async (
   account: string,
   dropLocalDatabase: boolean,
   isV3Enabled: boolean = true,
-  disconnectWallet: () => void,
   privyLogout: () => void
 ) => {
   logger.debug(
@@ -165,7 +163,6 @@ export const logoutAccount = async (
     }
   }
   await dropXmtpClient(await getInboxId(account));
-  disconnectWallet();
   const isPrivyAccount = !!useAccountsStore.getState().privyAccountId[account];
   if (isPrivyAccount) {
     privyLogout();
@@ -228,18 +225,11 @@ export const logoutAccount = async (
 
 export const useLogoutFromConverse = (account: string) => {
   const privyLogout = useDisconnectFromPrivy();
-  const disconnectWallet = useDisconnectWallet();
   const logout = useCallback(
     async (dropLocalDatabase: boolean, isV3Enabled: boolean = true) => {
-      logoutAccount(
-        account,
-        dropLocalDatabase,
-        isV3Enabled,
-        disconnectWallet,
-        privyLogout
-      );
+      logoutAccount(account, dropLocalDatabase, isV3Enabled, privyLogout);
     },
-    [account, disconnectWallet, privyLogout]
+    [account, privyLogout]
   );
   return logout;
 };

--- a/utils/logout/wallet.tsx
+++ b/utils/logout/wallet.tsx
@@ -2,10 +2,10 @@ import { useActiveWallet, useDisconnect } from "thirdweb/react";
 
 export const useDisconnectWallet = () => {
   const { disconnect: disconnectWallet } = useDisconnect();
-  const thirdwebWallet = useActiveWallet();
+  const activeWallet = useActiveWallet();
   return () => {
-    if (thirdwebWallet) {
-      disconnectWallet(thirdwebWallet);
+    if (activeWallet) {
+      disconnectWallet(activeWallet);
     }
   };
 };

--- a/utils/profile.ts
+++ b/utils/profile.ts
@@ -1,4 +1,4 @@
-import { getCleanAddress } from "./eth";
+import { getCleanAddress } from "./evm/address";
 import { shortAddress } from "./str";
 import { ProfileByAddress, ProfileSocials } from "../data/store/profilesStore";
 import { RecommendationData } from "../data/store/recommendationsStore";

--- a/utils/xmtpRN/client.ts
+++ b/utils/xmtpRN/client.ts
@@ -21,7 +21,7 @@ import { CoinbaseMessagingPaymentCodec } from "./contentTypes/coinbasePayment";
 import { getXmtpClient } from "./sync";
 import config from "../../config";
 import { getDbDirectory } from "../../data/db";
-import { getCleanAddress } from "../eth";
+import { getCleanAddress } from "../evm/address";
 
 const env = config.xmtpEnv as "dev" | "production" | "local";
 

--- a/utils/xmtpRN/client.web.ts
+++ b/utils/xmtpRN/client.web.ts
@@ -10,7 +10,7 @@ import { Client } from "@xmtp/xmtp-js";
 
 import { CoinbaseMessagingPaymentCodec } from "./contentTypes/coinbasePayment";
 import config from "../../config";
-import { getCleanAddress } from "../eth";
+import { getCleanAddress } from "../evm/address";
 
 const env = config.xmtpEnv as "dev" | "production" | "local";
 

--- a/utils/xmtpRN/conversations.ts
+++ b/utils/xmtpRN/conversations.ts
@@ -39,7 +39,7 @@ import {
   fetchGroupsQuery,
 } from "../../queries/useGroupsQuery";
 import { ConversationWithLastMessagePreview } from "../conversation";
-import { getCleanAddress } from "../eth";
+import { getCleanAddress } from "../evm/address";
 import { getTopicDataFromKeychain } from "../keychain/helpers";
 import { getSecureMmkvForAccount } from "../mmkv";
 import { sentryTrackError } from "../sentry";

--- a/utils/xmtpRN/conversations.web.ts
+++ b/utils/xmtpRN/conversations.web.ts
@@ -8,7 +8,7 @@ import { saveConversations } from "../../data/helpers/conversations/upsertConver
 import { getChatStore, getSettingsStore } from "../../data/store/accountsStore";
 import { XmtpConversation } from "../../data/store/chatStore";
 import { SettingsStoreType } from "../../data/store/settingsStore";
-import { getCleanAddress } from "../eth";
+import { getCleanAddress } from "../evm/address";
 
 const protocolConversationToStateConversation = (
   conversation: Conversation

--- a/utils/xmtpRN/messages.ts
+++ b/utils/xmtpRN/messages.ts
@@ -1,6 +1,6 @@
 import { entifyWithAddress } from "@queries/entify";
 import { setGroupMembersQueryData } from "@queries/useGroupMembersQuery";
-import { getCleanAddress } from "@utils/eth";
+import { getCleanAddress } from "@utils/evm/address";
 import logger from "@utils/logger";
 import { TransactionReference } from "@xmtp/content-type-transaction-reference";
 import {

--- a/utils/xmtpRN/revoke.ts
+++ b/utils/xmtpRN/revoke.ts
@@ -1,0 +1,49 @@
+import { translate } from "@i18n";
+import { awaitableAlert } from "@utils/alert";
+import logger from "@utils/logger";
+import { Client } from "@xmtp/react-native-sdk";
+import { Signer } from "ethers";
+
+export const getOtherInstallations = async (client: Client<any>) => {
+  const state = await client.inboxState(true);
+  logger.debug(
+    `Current installation id : ${client.installationId} - All installation ids : ${state.installationIds}`
+  );
+  const otherInstallations = state.installationIds.filter(
+    (installationId) => installationId !== client.installationId
+  );
+  logger.debug(
+    `Current installation id : ${client.installationId} - All installation ids : ${state.installationIds}`
+  );
+  return otherInstallations;
+};
+
+export const revokeOtherInstallations = async (
+  signer: Signer,
+  client: Client<any>,
+  otherInstallationsCount: number
+) => {
+  if (otherInstallationsCount === 0) return false;
+  logger.warn(
+    `Inbox ${client.inboxId} has ${otherInstallationsCount} installations to revoke`
+  );
+  // We're on a mobile wallet so we need to ask the user first
+  const doRevoke = await awaitableAlert(
+    translate("other_installations_count", {
+      count: otherInstallationsCount,
+    }),
+    translate("revoke_description"),
+    "Yes",
+    "No"
+  );
+  if (!doRevoke) {
+    logger.debug(`[Onboarding] User decided not to revoke`);
+    return false;
+  }
+  logger.debug(
+    `[Onboarding] User decided to revoke ${otherInstallationsCount} installation`
+  );
+  await client.revokeAllOtherInstallations(signer);
+  logger.debug(`[Onboarding] Installations revoked.`);
+  return true;
+};

--- a/utils/xmtpRN/revoke.ts
+++ b/utils/xmtpRN/revoke.ts
@@ -5,15 +5,13 @@ import { Client } from "@xmtp/react-native-sdk";
 import { Signer } from "ethers";
 
 export const getOtherInstallations = async (client: Client<any>) => {
-  const state = await client.inboxState(true);
+  const inboxState = await client.inboxState(true);
+  const installationsIds = inboxState.installations.map((i) => i.id);
   logger.debug(
-    `Current installation id : ${client.installationId} - All installation ids : ${state.installationIds}`
+    `Current installation id : ${client.installationId} - All installation ids : ${installationsIds}`
   );
-  const otherInstallations = state.installationIds.filter(
+  const otherInstallations = installationsIds.filter(
     (installationId) => installationId !== client.installationId
-  );
-  logger.debug(
-    `Current installation id : ${client.installationId} - All installation ids : ${state.installationIds}`
   );
   return otherInstallations;
 };


### PR DESCRIPTION
Implement revocation action from the UI (in Profile)

- cleanup evm utils
- rename existing web util (for tx frames)`useExternalProvider` to `useExternalSigner`
- implement a WalletPicker drawer UI, to select an external wallet to link to the app
- keep the wallet that was linked during onboarding into memory rather than forgetting it
- implement the `useExternalSigner` helper for react native using thirdweb
- implement a `useXmtpSigner` helper to get an external / privy signer that matches the XMTP client owner address
- implement the revoke method using that signer, to revoke other installations

Very excited about this one, this leads the way for transactional frames work next week!