### PR TITLE
Noe/text input deeplink

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -92,6 +92,8 @@
         <data android:host="dev.converse.xyz" android:pathPrefix="/dm" android:scheme="https"/>
         <data android:host="dev.getconverse.app" android:pathPrefix="/group-invite" android:scheme="https"/>
         <data android:host="dev.converse.xyz" android:pathPrefix="/group-invite" android:scheme="https"/>
+        <data android:host="dev.getconverse.app" android:pathPrefix="/group" android:scheme="https"/>
+        <data android:host="dev.converse.xyz" android:pathPrefix="/group" android:scheme="https"/>
         <data android:host="dev.getconverse.app" android:pathPrefix="/coinbase" android:scheme="https"/>
         <data android:host="dev.converse.xyz" android:pathPrefix="/coinbase" android:scheme="https"/>
         <data android:host="dev.getconverse.app" android:pathPrefix="/desktopconnect" android:scheme="https"/>

--- a/components/Chat/ChatPlaceholder/ChatPlaceholder.tsx
+++ b/components/Chat/ChatPlaceholder/ChatPlaceholder.tsx
@@ -1,5 +1,6 @@
 import { translate } from "@i18n";
 import { actionSheetColors, textPrimaryColor } from "@styles/colors";
+import { isGroupTopic } from "@utils/groupUtils/groupId";
 import {
   Keyboard,
   Platform,
@@ -31,6 +32,7 @@ type Props = {
 };
 
 export default function ChatPlaceholder({ messagesCount }: Props) {
+  const topic = useConversationContext("topic");
   const conversation = useConversationContext("conversation");
   const isBlockedPeer = useConversationContext("isBlockedPeer");
   const onReadyToFocus = useConversationContext("onReadyToFocus");
@@ -62,9 +64,13 @@ export default function ChatPlaceholder({ messagesCount }: Props) {
       >
         {!conversation && (
           <View>
-            <ActivityIndicator style={{ marginBottom: 20 }} />
+            {!topic && <ActivityIndicator style={{ marginBottom: 20 }} />}
             <Text style={styles.chatPlaceholderText}>
-              Opening your conversation
+              {topic
+                ? isGroupTopic(topic)
+                  ? translate("group_not_found")
+                  : translate("conversation_not_found")
+                : translate("opening_conversation")}
             </Text>
           </View>
         )}
@@ -152,6 +158,7 @@ const useStyles = () => {
       textAlign: "center",
       fontSize: Platform.OS === "android" ? 16 : 17,
       color: textPrimaryColor(colorScheme),
+      paddingHorizontal: 30,
     },
     cta: {
       alignSelf: "center",

--- a/components/Chat/Frame/FramePreview.tsx
+++ b/components/Chat/Frame/FramePreview.tsx
@@ -149,16 +149,21 @@ export default function FramePreview({
   const onButtonPress = useCallback(
     async (button: FrameButtonType) => {
       if (button.action === "link") {
+        if (!button.target) return;
         const link = button.target;
-        if (
-          !link ||
-          !(
-            link.startsWith("http") || link.startsWith(`${config.scheme}://`)
-          ) ||
-          !(await Linking.canOpenURL(link))
-        )
+        try {
+          const url = new URL(link);
+          if (
+            (url.protocol === "http:" ||
+              url.protocol === "https:" ||
+              url.protocol === `${config.scheme}:`) &&
+            (await Linking.canOpenURL(link))
+          ) {
+            Linking.openURL(link);
+          }
+        } catch {
           return;
-        Linking.openURL(link);
+        }
         return;
       }
       if (!conversation) return;

--- a/components/Chat/Frame/FramePreview.tsx
+++ b/components/Chat/Frame/FramePreview.tsx
@@ -152,7 +152,9 @@ export default function FramePreview({
         const link = button.target;
         if (
           !link ||
-          !link.startsWith("http") ||
+          !(
+            link.startsWith("http") || link.startsWith(`${config.scheme}://`)
+          ) ||
           !(await Linking.canOpenURL(link))
         )
           return;

--- a/components/ConversationListItem.tsx
+++ b/components/ConversationListItem.tsx
@@ -204,7 +204,7 @@ const ConversationListItem = memo(function ConversationListItem({
     }
     navigate("Conversation", {
       topic: conversationTopic,
-      message: routeParams?.frameURL,
+      text: routeParams?.frameURL,
     });
   }, [
     isGroupConversation,

--- a/components/StateHandlers/InitialStateHandler.tsx
+++ b/components/StateHandlers/InitialStateHandler.tsx
@@ -4,26 +4,15 @@ import * as Linking from "expo-linking";
 import { useCallback, useEffect, useRef } from "react";
 import { useColorScheme } from "react-native";
 
-import config from "../../config";
 import { useAppStore } from "../../data/store/appStore";
 import { useOnboardingStore } from "../../data/store/onboardingStore";
 import { useSelect } from "../../data/store/storeHelpers";
 import {
+  getSchemedURLFromUniversalURL,
   navigateToTopicWithRetry,
   topicToNavigateTo,
 } from "../../utils/navigation";
 import { hideSplashScreen } from "../../utils/splash/splash";
-
-const getSchemedURLFromUniversalURL = (url: string) => {
-  let schemedURL = url;
-  // Handling universal links by saving a schemed URI
-  config.universalLinks.forEach((prefix) => {
-    if (schemedURL.startsWith(prefix)) {
-      schemedURL = Linking.createURL(schemedURL.replace(prefix, ""));
-    }
-  });
-  return schemedURL;
-};
 
 const isDevelopmentClientURL = (url: string) => {
   return url.includes("expo-development-client");

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -198,6 +198,10 @@ const en = {
   if_you_block_contact:
     "If you block this contact, you will not receive messages from them anymore",
   opening_conversation: "Opening your conversation",
+  conversation_not_found:
+    "We couldn't find this conversation. Please try again",
+  group_not_found:
+    "We couldn't find this group. Please try again or ask someone to invite you to this group",
   say_hi: "Say hi",
   do_you_trust_this_contact: "Do you trust this contact?",
   do_you_want_to_join_this_group: "Do you want to join this group?",

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import "./wdyr";
 import "react-native-gesture-handler";
+import "react-native-url-polyfill/auto";
 import { registerRootComponent } from "expo";
 
 import App from "./App";

--- a/screens/Conversation.tsx
+++ b/screens/Conversation.tsx
@@ -152,8 +152,8 @@ const Conversation = ({
   const mediaPreviewRef = useRef<MediaPreview>();
 
   const messageToPrefill = useMemo(
-    () => route.params?.message || conversation?.messageDraft || "",
-    [conversation?.messageDraft, route.params?.message]
+    () => route.params?.text || conversation?.messageDraft || "",
+    [conversation?.messageDraft, route.params?.text]
   );
   const mediaPreviewToPrefill = useMemo(
     () => conversation?.mediaPreview || null,

--- a/screens/Conversation.tsx
+++ b/screens/Conversation.tsx
@@ -289,6 +289,7 @@ const Conversation = ({
       {route.params?.topic || route.params?.mainConversationWithPeer ? (
         <ConversationContext.Provider
           value={{
+            topic: conversationTopic,
             conversation,
             messageToPrefill,
             inputRef: textInputRef,

--- a/screens/Navigation/ConversationNav.tsx
+++ b/screens/Navigation/ConversationNav.tsx
@@ -17,7 +17,7 @@ import Conversation from "../Conversation";
 
 export type ConversationNavParams = {
   topic?: string;
-  message?: string;
+  text?: string;
   focus?: boolean;
   mainConversationWithPeer?: string;
 };

--- a/screens/Navigation/Navigation.tsx
+++ b/screens/Navigation/Navigation.tsx
@@ -89,7 +89,7 @@ const linking = {
       WebviewPreview: WebviewPreviewScreenConfig,
     },
   },
-  getStateFromPath: getConverseStateFromPath,
+  getStateFromPath: getConverseStateFromPath("fullStackNavigation"),
   getInitialURL: getConverseInitialURL,
 };
 

--- a/screens/Navigation/SplitScreenNavigation/SplitRightStackNavigation.tsx
+++ b/screens/Navigation/SplitScreenNavigation/SplitRightStackNavigation.tsx
@@ -71,7 +71,7 @@ const linking = {
       WebviewPreview: WebviewPreviewScreenConfig,
     },
   },
-  getStateFromPath: getConverseStateFromPath,
+  getStateFromPath: getConverseStateFromPath("splitRightStack"),
   getInitialURL: getConverseInitialURL,
 };
 

--- a/screens/Navigation/SplitScreenNavigation/SplitScreenNavigation.tsx
+++ b/screens/Navigation/SplitScreenNavigation/SplitScreenNavigation.tsx
@@ -36,7 +36,7 @@ const linking = {
       Conversation: ConversationScreenConfig,
     },
   },
-  getStateFromPath: getConverseStateFromPath,
+  getStateFromPath: getConverseStateFromPath("splitScreen"),
   getInitialURL: getConverseInitialURL,
 };
 

--- a/screens/Navigation/navHelpers.test.ts
+++ b/screens/Navigation/navHelpers.test.ts
@@ -1,0 +1,134 @@
+import { getConverseStateFromPath } from "./navHelpers";
+
+jest.mock("../../components/StateHandlers/InitialStateHandler", () => ({
+  initialURL: "",
+}));
+
+describe("getConverseStateFromPath", () => {
+  const navConfig = {
+    initialRouteName: "Chats",
+    screens: {
+      Chats: "/",
+      Conversation: {
+        path: "/conversation",
+      },
+      NewConversation: {
+        path: "/newConversation",
+      },
+      Profile: {
+        path: "/profile",
+      },
+      Group: {
+        path: "/group",
+      },
+      GroupLink: {
+        path: "/groupLink/:groupLinkId",
+      },
+      GroupInvite: {
+        path: "/group-invite/:groupInviteId",
+      },
+      ShareProfile: {
+        path: "/shareProfile",
+      },
+      WebviewPreview: {
+        path: "/webviewPreview",
+      },
+    },
+  };
+
+  it("should parse simple dm deeplink", () => {
+    const state = getConverseStateFromPath("testNav")(
+      "dm?peer=0xno12.eth",
+      navConfig
+    );
+    const route = state?.routes[state.routes.length - 1];
+    expect(route?.name).toBe("Conversation");
+    expect((route?.params as any).mainConversationWithPeer).toBe("0xno12.eth");
+    expect((route?.params as any).text).toBeUndefined();
+  });
+
+  it("should parse simple dm universal link", () => {
+    const state = getConverseStateFromPath("testNav")(
+      "dm/0xno12.eth",
+      navConfig
+    );
+    const route = state?.routes[state.routes.length - 1];
+    expect(route?.name).toBe("Conversation");
+    expect((route?.params as any).mainConversationWithPeer).toBe("0xno12.eth");
+    expect((route?.params as any).text).toBeUndefined();
+  });
+
+  it("should parse simple group deeplink", () => {
+    const state = getConverseStateFromPath("testNav")(
+      "group?groupId=f7349f84925aaeee5816d02b7798efbc",
+      navConfig
+    );
+    const route = state?.routes[state.routes.length - 1];
+    expect(route?.name).toBe("Conversation");
+    expect((route?.params as any).topic).toBe(
+      "/xmtp/mls/1/g-f7349f84925aaeee5816d02b7798efbc/proto"
+    );
+    expect((route?.params as any).text).toBeUndefined();
+  });
+
+  it("should parse simple group universal link", () => {
+    const state = getConverseStateFromPath("testNav")(
+      "group/f7349f84925aaeee5816d02b7798efbc",
+      navConfig
+    );
+    const route = state?.routes[state.routes.length - 1];
+    expect(route?.name).toBe("Conversation");
+    expect((route?.params as any).topic).toBe(
+      "/xmtp/mls/1/g-f7349f84925aaeee5816d02b7798efbc/proto"
+    );
+    expect((route?.params as any).text).toBeUndefined();
+  });
+
+  it("should parse simple dm deeplink with text", () => {
+    const state = getConverseStateFromPath("testNav")(
+      "dm?peer=0xno12.eth&text=hello",
+      navConfig
+    );
+    const route = state?.routes[state.routes.length - 1];
+    expect(route?.name).toBe("Conversation");
+    expect((route?.params as any).mainConversationWithPeer).toBe("0xno12.eth");
+    expect((route?.params as any).text).toBe("hello");
+  });
+
+  it("should parse simple dm universal link with text", () => {
+    const state = getConverseStateFromPath("testNav")(
+      "dm/0xno12.eth?text=hello",
+      navConfig
+    );
+    const route = state?.routes[state.routes.length - 1];
+    expect(route?.name).toBe("Conversation");
+    expect((route?.params as any).mainConversationWithPeer).toBe("0xno12.eth");
+    expect((route?.params as any).text).toBe("hello");
+  });
+
+  it("should parse simple group deeplink with text", () => {
+    const state = getConverseStateFromPath("testNav")(
+      "group?groupId=f7349f84925aaeee5816d02b7798efbc&text=hello",
+      navConfig
+    );
+    const route = state?.routes[state.routes.length - 1];
+    expect(route?.name).toBe("Conversation");
+    expect((route?.params as any).topic).toBe(
+      "/xmtp/mls/1/g-f7349f84925aaeee5816d02b7798efbc/proto"
+    );
+    expect((route?.params as any).text).toBe("hello");
+  });
+
+  it("should parse simple group universal link with text", () => {
+    const state = getConverseStateFromPath("testNav")(
+      "group/f7349f84925aaeee5816d02b7798efbc?text=hello",
+      navConfig
+    );
+    const route = state?.routes[state.routes.length - 1];
+    expect(route?.name).toBe("Conversation");
+    expect((route?.params as any).topic).toBe(
+      "/xmtp/mls/1/g-f7349f84925aaeee5816d02b7798efbc/proto"
+    );
+    expect((route?.params as any).text).toBe("hello");
+  });
+});

--- a/screens/Navigation/navHelpers.ts
+++ b/screens/Navigation/navHelpers.ts
@@ -55,6 +55,10 @@ export const getConverseStateFromPath =
     } else if (pathForState?.startsWith("groupInvite")) {
       // TODO: Remove this once enough users have updated (September 30, 2024)
       pathForState = pathForState.replace("groupInvite", "group-invite");
+    } else if (pathForState?.startsWith("?text=")) {
+      const url = new URL(`https://${config.websiteDomain}/${pathForState}`);
+      const params = new URLSearchParams(url.search);
+      setOpenedConversationText({ text: params.get("text"), navigationName });
     }
 
     // Prevent navigation
@@ -76,17 +80,7 @@ const handleConversationLink = ({
   text?: string | null;
 }) => {
   if (!groupId && !peer) {
-    if (text) {
-      // If navigating but no group or peer, we can still prefill message for current convo
-      const navigationState = navigationStates[navigationName];
-      const currentRoutes = navigationState?.state.routes || [];
-      if (
-        currentRoutes.length > 0 &&
-        currentRoutes[currentRoutes.length - 1].name === "Conversation"
-      ) {
-        converseEventEmitter.emit("setCurrentConversationInputValue", text);
-      }
-    }
+    setOpenedConversationText({ text, navigationName });
     return;
   }
   const parameters: { [param: string]: string } = { focus: "true" };
@@ -100,6 +94,26 @@ const handleConversationLink = ({
   }
   const queryString = new URLSearchParams(parameters).toString();
   return `conversation?${queryString}`;
+};
+
+const setOpenedConversationText = ({
+  text,
+  navigationName,
+}: {
+  text?: string | null;
+  navigationName: string;
+}) => {
+  if (text) {
+    // If navigating but no group or peer, we can still prefill message for current convo
+    const navigationState = navigationStates[navigationName];
+    const currentRoutes = navigationState?.state.routes || [];
+    if (
+      currentRoutes.length > 0 &&
+      currentRoutes[currentRoutes.length - 1].name === "Conversation"
+    ) {
+      converseEventEmitter.emit("setCurrentConversationInputValue", text);
+    }
+  }
 };
 
 export const getConverseInitialURL = () => {

--- a/screens/Navigation/navHelpers.ts
+++ b/screens/Navigation/navHelpers.ts
@@ -46,7 +46,7 @@ export const getConverseStateFromPath =
     } else if (pathForState?.startsWith("group/")) {
       const url = new URL(`https://${config.websiteDomain}/${pathForState}`);
       const params = new URLSearchParams(url.search);
-      const groupId = url.pathname.slice(6).trim();
+      const groupId = url.pathname.slice(7).trim();
       pathForState = handleConversationLink({
         navigationName,
         groupId,

--- a/utils/conversation.ts
+++ b/utils/conversation.ts
@@ -18,9 +18,9 @@ import { getMatchedPeerAddresses } from "./search";
 import { sentryTrackMessage } from "./sentry";
 import { TextInputWithValue, addressPrefix } from "./str";
 import { isTransactionMessage } from "./transaction";
+import config from "../config";
 import { isOnXmtp } from "./xmtpRN/client";
 import { isContentType } from "./xmtpRN/contentTypes";
-import config from "../config";
 import { createPendingConversation } from "../data/helpers/conversations/pendingConversations";
 import { getChatStore, useChatStore } from "../data/store/accountsStore";
 import {
@@ -270,6 +270,7 @@ export const openMainConversationWithPeer = async (
 };
 
 export type ConversationContextType = {
+  topic?: string;
   conversation?: XmtpConversationWithUpdate;
   inputRef: MutableRefObject<TextInputWithValue | undefined>;
   mediaPreviewRef: MutableRefObject<MediaPreview | undefined>;
@@ -287,6 +288,7 @@ export type ConversationContextType = {
 };
 
 export const ConversationContext = createContext<ConversationContextType>({
+  topic: undefined,
   conversation: undefined,
   inputRef: createRef() as MutableRefObject<TextInputWithValue | undefined>,
   mediaPreviewRef: createRef() as MutableRefObject<MediaPreview | undefined>,

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -1,5 +1,9 @@
+import * as Linking from "expo-linking";
+import { Linking as RNLinking } from "react-native";
+
 import logger from "./logger";
 import { loadSavedNotificationMessagesToContext } from "./notifications";
+import config from "../config";
 import { currentAccount, getChatStore } from "../data/store/accountsStore";
 import { XmtpConversation } from "../data/store/chatStore";
 import { NavigationParamList } from "../screens/Navigation/Navigation";
@@ -54,4 +58,36 @@ export const navigateToTopicWithRetry = async () => {
   if (topicToNavigateTo && conversationToNavigateTo) {
     navigateToConversation(conversationToNavigateTo);
   }
+};
+
+export const getSchemedURLFromUniversalURL = (url: string) => {
+  // Handling universal links by saving a schemed URI
+  for (const prefix of config.universalLinks) {
+    if (url.startsWith(prefix)) {
+      return Linking.createURL(url.replace(prefix, ""));
+    }
+  }
+  return url;
+};
+
+const isDMLink = (url: string) => {
+  for (const prefix of config.universalLinks) {
+    if (url.startsWith(prefix)) {
+      const path = url.slice(prefix.length);
+      if (path.toLowerCase().startsWith("dm/")) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+const originalOpenURL = RNLinking.openURL.bind(RNLinking);
+RNLinking.openURL = (url: string) => {
+  // If the URL is a DM link, open it inside the app
+  // as a deeplink, not the browser
+  if (isDMLink(url)) {
+    return originalOpenURL(getSchemedURLFromUniversalURL(url));
+  }
+  return originalOpenURL(url);
 };


### PR DESCRIPTION
Implementing #908 

Goal is to be able to
- deeplink to a group knowing its group id, & optionally prefill the text input
- deeplink to a 1:1 knowing the peer address (already implemented!) & optionally prefill the text input (new!)
- prefill the text input for the currently opened conversation without knowing anything about it (from a frame for instance)

This PR does the following:

- introduces a more robust deeplink method parsing for conversations, to parse various arguments (`peer`, `groupId`, `text`)
- renames the existing `message` parameter to `text` on Conversation params
- ability to have converse deeplinks (converse://) in frames
- ability to click dm universal links (https://converse.xyz/dm/...) in app without being redirected to safari
- new group deeplink if we know the group id, redirecting to the group and telling the user if the group is unknown (not a part of the group)

Effectively, here are the converse scheme deeplinks that now work (adapt with converse-dev:// to test locally)

- `converse://dm?peer=0xno12.eth` to open / create the main 1:1 convo with 0xno12.eth. Already existed!
- `converse://dm?peer=0xno12.eth&text=hello` to open / create the main 1:1 convo with 0xno12.eth & prefill text with string `hello`
- `converse://group?groupId=f7349f84925aaeee5816d02b7798efbc` to navigate to group with id `f7349f84925aaeee5816d02b7798efbc` locally if it exists
- `converse://group?groupId=f7349f84925aaeee5816d02b7798efbc&text=hello` to navigate to group with id `f7349f84925aaeee5816d02b7798efbc` locally if it exists and prefill text with string `hello`
- `converse://?text=hello` to fill the text input of the currently active convo

Here are the universal links that are also introduced (adapt with https://dev.converse.xyz to test locally)

- `https://converse.xyz/dm/0xno12.eth` to open / create the main 1:1 convo with 0xno12.eth. Already existed!
- `https://converse.xyz/dm/0xno12.eth?text=hello` to open / create the main 1:1 convo with 0xno12.eth & prefill text with string `hello`. Also the website has been adapted in [that PR](https://github.com/ephemeraHQ/converse-website/pull/15/files) to pass the `text` parameter to the converse deeplink if it got opened in Safari for instance

However some universal links do not exist yet

-  `https://converse.xyz/?text=hello` because we cannot have a universal link on the root `/` because it would prevent smartphone users from navigating to our home page
- `https://converse.xyz/group/f7349f84925aaeee5816d02b7798efbc?text=hello` to navigate to a group page (with or without `text`). This one should work as a universal link (to automatically open converse if clicked) but we are unable to create a matching webpage (in case it is opened in Safari) because we don't have information on the group from the group id. We would need to present an anonymous group page with a button with a custom scheme link, but I think we can do that later


So for Frames cc @fabriguespe , the recommendation would be to use custom scheme deeplinks rather than universal links for a while (these actions would be best with custom open frames actions I think anyway, to work cross client)