### PR TITLE
fix: convo key change when group members change

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -428,9 +428,9 @@ export function Chat() {
   return (
     <View
       style={styles.chatContainer}
-      key={`chat-${conversation?.peerAddress}-${
-        conversation?.context?.conversationId || ""
-      }-${isBlockedPeer}`}
+      key={`chat-${
+        conversation?.isGroup ? conversation?.topic : conversation?.peerAddress
+      }-${conversation?.context?.conversationId || ""}-${isBlockedPeer}`}
     >
       <Animated.View style={chatContentStyle}>
         {conversation && listArray.length > 0 && !isBlockedPeer && (


### PR DESCRIPTION
fixes #910 
we are using a conversation key to force a full rerender in some specific cases but it was never adapted to groups (it used peerAddress rather than topic to handle 1:1 convos  pending creation / 1st message) 