### PR TITLE
chore: Add Min system version for macos warning

### DIFF
--- a/ios/Converse/Info.plist
+++ b/ios/Converse/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSMinimumSystemVersion</key>
+	<string>12.0</string>
 	<key>AppGroup</key>
 	<string>group.$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>AppGroupName</key>


### PR DESCRIPTION
Added LSMinimumSystemVersion to 12.0 from app store connect emails