### PR TITLE
fix: Group Invite screen on iPad

### DIFF
--- a/screens/Navigation/SplitScreenNavigation/SplitRightStackNavigation.tsx
+++ b/screens/Navigation/SplitScreenNavigation/SplitRightStackNavigation.tsx
@@ -13,6 +13,7 @@ import ConversationNav, {
   ConversationScreenConfig,
 } from "../ConversationNav";
 import EnableTransactionsNav from "../EnableTransactionsNav";
+import GroupInviteNav from "../GroupInviteNav";
 import GroupLinkNav, {
   GroupLinkNavParams,
   GroupLinkScreenConfig,
@@ -110,6 +111,7 @@ export default function SplitRightStackNavigation({
           {GroupNav()}
           {GroupLinkNav()}
           {UserProfileNav()}
+          {GroupInviteNav()}
           {TopUpNav()}
           {EnableTransactionsNav()}
         </NativeStack.Group>


### PR DESCRIPTION
Added Group Invite screen to SplitScreen navigation