### PR TITLE
Rolled-up reactions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,12 +7,9 @@ import { ActionSheetProvider } from "@expo/react-native-action-sheet";
 import { PortalProvider } from "@gorhom/portal";
 import { PrivyProvider } from "@privy-io/expo";
 import { queryClient } from "@queries/queryClient";
-import {
-  backgroundColor,
-  MaterialDarkTheme,
-  MaterialLightTheme,
-} from "@styles/colors";
+import { MaterialDarkTheme, MaterialLightTheme } from "@styles/colors";
 import { QueryClientProvider } from "@tanstack/react-query";
+import { useAppTheme, useThemeProvider } from "@theme/useAppTheme";
 import { useCoinbaseWalletListener } from "@utils/coinbaseWallet";
 import { converseEventEmitter } from "@utils/events";
 import logger from "@utils/logger";
@@ -38,7 +35,6 @@ import {
   updateLastVersionOpen,
 } from "./data/updates/asyncUpdates";
 import Main from "./screens/Main";
-import { useThemeProvider } from "./theme/useAppTheme";
 import { registerBackgroundFetchTask } from "./utils/background";
 import { privySecureStorage } from "./utils/keychain/helpers";
 import { initSentry } from "./utils/sentry";
@@ -142,15 +138,16 @@ export default function AppWithProviders() {
 }
 
 const useStyles = () => {
-  const colorScheme = useColorScheme();
+  const { theme } = useAppTheme();
+
   return useMemo(
     () =>
       StyleSheet.create({
         safe: {
           flex: 1,
-          backgroundColor: backgroundColor(colorScheme),
+          backgroundColor: theme.colors.background.surface,
         },
       }),
-    [colorScheme]
+    [theme]
   );
 };

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -1,9 +1,6 @@
 import { FlashList } from "@shopify/flash-list";
-import {
-  backgroundColor,
-  itemSeparatorColor,
-  tertiaryBackgroundColor,
-} from "@styles/colors";
+import { itemSeparatorColor, tertiaryBackgroundColor } from "@styles/colors";
+import { useAppTheme } from "@theme/useAppTheme";
 import { getCleanAddress } from "@utils/evm/address";
 import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
@@ -606,31 +603,33 @@ export function ChatPreview() {
 
 const useStyles = () => {
   const colorScheme = useColorScheme();
+  const { theme } = useAppTheme();
+
   return useMemo(
     () =>
       StyleSheet.create({
         chatContainer: {
           flex: 1,
           justifyContent: "flex-end",
-          backgroundColor: backgroundColor(colorScheme),
+          backgroundColor: theme.colors.background.surface,
         },
         chatContent: {
-          backgroundColor: backgroundColor(colorScheme),
+          backgroundColor: theme.colors.background.surface,
           flex: 1,
         },
         chatPreviewContent: {
-          backgroundColor: backgroundColor(colorScheme),
+          backgroundColor: theme.colors.background.surface,
           flex: 1,
           paddingBottom: 0,
         },
         chat: {
-          backgroundColor: backgroundColor(colorScheme),
+          backgroundColor: theme.colors.background.surface,
         },
         inputBottomFiller: {
           position: "absolute",
           width: "100%",
           bottom: 0,
-          backgroundColor: backgroundColor(colorScheme),
+          backgroundColor: theme.colors.background.surface,
           zIndex: 0,
         },
         inChatRecommendations: {
@@ -640,6 +639,6 @@ const useStyles = () => {
           marginBottom: 10,
         },
       }),
-    [colorScheme]
+    [colorScheme, theme]
   );
 };

--- a/components/Chat/Input/Input.tsx
+++ b/components/Chat/Input/Input.tsx
@@ -4,8 +4,8 @@ import {
   itemSeparatorColor,
   textPrimaryColor,
   textSecondaryColor,
-  backgroundColor,
 } from "@styles/colors";
+import { useAppTheme } from "@theme/useAppTheme";
 import React, {
   useCallback,
   useMemo,
@@ -484,9 +484,11 @@ export default function ChatInput({ inputHeight }: ChatInputProps) {
 
 const useStyles = () => {
   const colorScheme = useColorScheme();
+  const { theme } = useAppTheme();
+
   return StyleSheet.create({
     chatInputWrapper: {
-      backgroundColor: backgroundColor(colorScheme),
+      backgroundColor: theme.colors.background.surface,
       width: "100%",
       bottom: 0,
     },
@@ -495,7 +497,7 @@ const useStyles = () => {
       paddingVertical: 8,
       borderTopWidth: 0.5,
       borderTopColor: itemSeparatorColor(colorScheme),
-      backgroundColor: backgroundColor(colorScheme),
+      backgroundColor: theme.colors.background.surface,
     },
     chatInputContainer: {
       flexDirection: "row",

--- a/components/Chat/Input/InputReplyPreview.tsx
+++ b/components/Chat/Input/InputReplyPreview.tsx
@@ -1,9 +1,6 @@
-import {
-  backgroundColor,
-  textPrimaryColor,
-  textSecondaryColor,
-} from "@styles/colors";
+import { textPrimaryColor, textSecondaryColor } from "@styles/colors";
 import { PictoSizes } from "@styles/sizes";
+import { useAppTheme } from "@theme/useAppTheme";
 import {
   Platform,
   StyleSheet,
@@ -78,6 +75,8 @@ export default function ChatInputReplyPreview({
 
 const useStyles = () => {
   const colorScheme = useColorScheme();
+  const { theme } = useAppTheme();
+
   return StyleSheet.create({
     replyContainer: {
       ...Platform.select({
@@ -85,7 +84,7 @@ const useStyles = () => {
         android: {},
         web: {},
       }),
-      backgroundColor: backgroundColor(colorScheme),
+      backgroundColor: theme.colors.background.surface,
       alignItems: "center",
       flexDirection: "row",
     },

--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -576,122 +576,118 @@ export default function CachedChatMessage({
 
 const useStyles = () => {
   const colorScheme = useColorScheme();
-  return useMemo(
-    () =>
-      StyleSheet.create({
-        messageContainer: {
-          flexDirection: "row",
-          width: "100%",
-          alignItems: "flex-end",
-        },
-        innerBubble: {
-          backgroundColor: messageInnerBubbleColor(colorScheme),
-          borderRadius: 14,
-          paddingHorizontal: 12,
-          paddingVertical: 10,
-          marginTop: 10,
-          marginHorizontal: 10,
-        },
-        innerBubbleMe: {
-          backgroundColor: myMessageInnerBubbleColor(colorScheme),
-        },
-        messageRow: {
-          flexDirection: "row",
-          flexWrap: "wrap",
-        },
-        messageSwipeable: {
-          width: "100%",
-          flexDirection: "row",
-          paddingLeft: 12,
-          paddingRight: 15,
-          overflow: "visible",
-        },
-        messageSwipeableChildren: {
-          width: "100%",
-          flexDirection: "row",
-          flexWrap: "wrap",
-        },
-        linkToFrame: {
-          fontSize: 12,
-          padding: 6,
-          color: textSecondaryColor(colorScheme),
-          flexGrow: 1,
-        },
-        dateTimeContainer: {
-          width: "100%",
-          flexDirection: "row",
-          justifyContent: "center",
-          alignItems: "center",
-        },
-        dateTime: {
-          textAlign: "center",
-          fontSize: 12,
-          color: textSecondaryColor(colorScheme),
-          marginTop: 12,
-          marginBottom: 8,
-          fontWeight: "bold",
-          height: 20,
-        },
-        replyToUsername: {
-          fontSize: 12,
-          marginBottom: 4,
-          color: textSecondaryColor(colorScheme),
-          paddingVertical: 0,
-          paddingHorizontal: 0,
-        },
-        messageContentContainer: {
-          paddingHorizontal: 13,
-          paddingVertical: 6,
-        },
-        messageText: {
-          color: textPrimaryColor(colorScheme),
-          fontSize: 17,
-        },
-        messageTextMe: {
-          color: inversePrimaryColor(colorScheme),
-        },
-        allEmojisAndMaxThree: {
-          fontSize: 64,
-          paddingHorizontal: 0,
-        },
-        messageTextReply: {
-          color: textPrimaryColor(colorScheme),
-        },
-        messageTextReplyMe: {
-          color: inversePrimaryColor(colorScheme),
-        },
-        groupSenderAvatarWrapper: {
-          marginRight: 6,
-        },
-        groupSenderWrapper: {
-          flexDirection: "row",
-          flexBasis: "100%",
-        },
-        groupSender: {
-          fontSize: 12,
-          color: textSecondaryColor(colorScheme),
-          marginLeft: 10,
-          marginVertical: 4,
-        },
-        avatarPlaceholder: {
-          width: AvatarSizes.messageSender,
-          height: AvatarSizes.messageSender,
-        },
-        outsideContentRow: {
-          marginTop: 1,
-          flexDirection: "row",
-          justifyContent: "flex-start",
-          columnGap: 8,
-          width: "100%",
-        },
-        reactionsContainer: {
-          marginHorizontal: 8,
-          marginBottom: 8,
-        },
-        outsideReactionsContainer: {
-          flex: 1,
-        },
-      }),
-    [colorScheme]
-  );
+  return StyleSheet.create({
+    messageContainer: {
+      flexDirection: "row",
+      width: "100%",
+      alignItems: "flex-end",
+    },
+    innerBubble: {
+      backgroundColor: messageInnerBubbleColor(colorScheme),
+      borderRadius: 14,
+      paddingHorizontal: 12,
+      paddingVertical: 10,
+      marginTop: 10,
+      marginHorizontal: 10,
+    },
+    innerBubbleMe: {
+      backgroundColor: myMessageInnerBubbleColor(colorScheme),
+    },
+    messageRow: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+    },
+    messageSwipeable: {
+      width: "100%",
+      flexDirection: "row",
+      paddingLeft: 12,
+      paddingRight: 15,
+      overflow: "visible",
+    },
+    messageSwipeableChildren: {
+      width: "100%",
+      flexDirection: "row",
+      flexWrap: "wrap",
+    },
+    linkToFrame: {
+      fontSize: 12,
+      padding: 6,
+      color: textSecondaryColor(colorScheme),
+      flexGrow: 1,
+    },
+    dateTimeContainer: {
+      width: "100%",
+      flexDirection: "row",
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    dateTime: {
+      textAlign: "center",
+      fontSize: 12,
+      color: textSecondaryColor(colorScheme),
+      marginTop: 12,
+      marginBottom: 8,
+      fontWeight: "bold",
+      height: 20,
+    },
+    replyToUsername: {
+      fontSize: 12,
+      marginBottom: 4,
+      color: textSecondaryColor(colorScheme),
+      paddingVertical: 0,
+      paddingHorizontal: 0,
+    },
+    messageContentContainer: {
+      paddingHorizontal: 13,
+      paddingVertical: 6,
+    },
+    messageText: {
+      color: textPrimaryColor(colorScheme),
+      fontSize: 17,
+    },
+    messageTextMe: {
+      color: inversePrimaryColor(colorScheme),
+    },
+    allEmojisAndMaxThree: {
+      fontSize: 64,
+      paddingHorizontal: 0,
+    },
+    messageTextReply: {
+      color: textPrimaryColor(colorScheme),
+    },
+    messageTextReplyMe: {
+      color: inversePrimaryColor(colorScheme),
+    },
+    groupSenderAvatarWrapper: {
+      marginRight: 6,
+    },
+    groupSenderWrapper: {
+      flexDirection: "row",
+      flexBasis: "100%",
+    },
+    groupSender: {
+      fontSize: 12,
+      color: textSecondaryColor(colorScheme),
+      marginLeft: 10,
+      marginVertical: 4,
+    },
+    avatarPlaceholder: {
+      width: AvatarSizes.messageSender,
+      height: AvatarSizes.messageSender,
+    },
+    outsideContentRow: {
+      marginTop: 1,
+      flexDirection: "row",
+      justifyContent: "flex-start",
+      columnGap: 8,
+      width: "100%",
+    },
+    reactionsContainer: {
+      marginHorizontal: 8,
+      marginBottom: 8,
+    },
+    outsideReactionsContainer: {
+      flex: 1,
+    },
+  });
 };

--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -29,7 +29,7 @@ import Animated, {
 } from "react-native-reanimated";
 
 import ChatMessageActions from "./MessageActions";
-import ChatMessageReactions from "./MessageReactions";
+import { ChatMessageReactions } from "./MessageReactions";
 import MessageStatus from "./MessageStatus";
 import {
   currentAccount,

--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -576,118 +576,122 @@ export default function CachedChatMessage({
 
 const useStyles = () => {
   const colorScheme = useColorScheme();
-  return StyleSheet.create({
-    messageContainer: {
-      flexDirection: "row",
-      width: "100%",
-      alignItems: "flex-end",
-    },
-    innerBubble: {
-      backgroundColor: messageInnerBubbleColor(colorScheme),
-      borderRadius: 14,
-      paddingHorizontal: 12,
-      paddingVertical: 10,
-      marginTop: 10,
-      marginHorizontal: 10,
-    },
-    innerBubbleMe: {
-      backgroundColor: myMessageInnerBubbleColor(colorScheme),
-    },
-    messageRow: {
-      flexDirection: "row",
-      flexWrap: "wrap",
-    },
-    messageSwipeable: {
-      width: "100%",
-      flexDirection: "row",
-      paddingLeft: 12,
-      paddingRight: 15,
-      overflow: "visible",
-    },
-    messageSwipeableChildren: {
-      width: "100%",
-      flexDirection: "row",
-      flexWrap: "wrap",
-    },
-    linkToFrame: {
-      fontSize: 12,
-      padding: 6,
-      color: textSecondaryColor(colorScheme),
-      flexGrow: 1,
-    },
-    dateTimeContainer: {
-      width: "100%",
-      flexDirection: "row",
-      justifyContent: "center",
-      alignItems: "center",
-    },
-    dateTime: {
-      textAlign: "center",
-      fontSize: 12,
-      color: textSecondaryColor(colorScheme),
-      marginTop: 12,
-      marginBottom: 8,
-      fontWeight: "bold",
-      height: 20,
-    },
-    replyToUsername: {
-      fontSize: 12,
-      marginBottom: 4,
-      color: textSecondaryColor(colorScheme),
-      paddingVertical: 0,
-      paddingHorizontal: 0,
-    },
-    messageContentContainer: {
-      paddingHorizontal: 13,
-      paddingVertical: 6,
-    },
-    messageText: {
-      color: textPrimaryColor(colorScheme),
-      fontSize: 17,
-    },
-    messageTextMe: {
-      color: inversePrimaryColor(colorScheme),
-    },
-    allEmojisAndMaxThree: {
-      fontSize: 64,
-      paddingHorizontal: 0,
-    },
-    messageTextReply: {
-      color: textPrimaryColor(colorScheme),
-    },
-    messageTextReplyMe: {
-      color: inversePrimaryColor(colorScheme),
-    },
-    groupSenderAvatarWrapper: {
-      marginRight: 6,
-    },
-    groupSenderWrapper: {
-      flexDirection: "row",
-      flexBasis: "100%",
-    },
-    groupSender: {
-      fontSize: 12,
-      color: textSecondaryColor(colorScheme),
-      marginLeft: 10,
-      marginVertical: 4,
-    },
-    avatarPlaceholder: {
-      width: AvatarSizes.messageSender,
-      height: AvatarSizes.messageSender,
-    },
-    outsideContentRow: {
-      marginTop: 1,
-      flexDirection: "row",
-      justifyContent: "flex-start",
-      columnGap: 8,
-      width: "100%",
-    },
-    reactionsContainer: {
-      marginHorizontal: 8,
-      marginBottom: 8,
-    },
-    outsideReactionsContainer: {
-      flex: 1,
-    },
-  });
+  return useMemo(
+    () =>
+      StyleSheet.create({
+        messageContainer: {
+          flexDirection: "row",
+          width: "100%",
+          alignItems: "flex-end",
+        },
+        innerBubble: {
+          backgroundColor: messageInnerBubbleColor(colorScheme),
+          borderRadius: 14,
+          paddingHorizontal: 12,
+          paddingVertical: 10,
+          marginTop: 10,
+          marginHorizontal: 10,
+        },
+        innerBubbleMe: {
+          backgroundColor: myMessageInnerBubbleColor(colorScheme),
+        },
+        messageRow: {
+          flexDirection: "row",
+          flexWrap: "wrap",
+        },
+        messageSwipeable: {
+          width: "100%",
+          flexDirection: "row",
+          paddingLeft: 12,
+          paddingRight: 15,
+          overflow: "visible",
+        },
+        messageSwipeableChildren: {
+          width: "100%",
+          flexDirection: "row",
+          flexWrap: "wrap",
+        },
+        linkToFrame: {
+          fontSize: 12,
+          padding: 6,
+          color: textSecondaryColor(colorScheme),
+          flexGrow: 1,
+        },
+        dateTimeContainer: {
+          width: "100%",
+          flexDirection: "row",
+          justifyContent: "center",
+          alignItems: "center",
+        },
+        dateTime: {
+          textAlign: "center",
+          fontSize: 12,
+          color: textSecondaryColor(colorScheme),
+          marginTop: 12,
+          marginBottom: 8,
+          fontWeight: "bold",
+          height: 20,
+        },
+        replyToUsername: {
+          fontSize: 12,
+          marginBottom: 4,
+          color: textSecondaryColor(colorScheme),
+          paddingVertical: 0,
+          paddingHorizontal: 0,
+        },
+        messageContentContainer: {
+          paddingHorizontal: 13,
+          paddingVertical: 6,
+        },
+        messageText: {
+          color: textPrimaryColor(colorScheme),
+          fontSize: 17,
+        },
+        messageTextMe: {
+          color: inversePrimaryColor(colorScheme),
+        },
+        allEmojisAndMaxThree: {
+          fontSize: 64,
+          paddingHorizontal: 0,
+        },
+        messageTextReply: {
+          color: textPrimaryColor(colorScheme),
+        },
+        messageTextReplyMe: {
+          color: inversePrimaryColor(colorScheme),
+        },
+        groupSenderAvatarWrapper: {
+          marginRight: 6,
+        },
+        groupSenderWrapper: {
+          flexDirection: "row",
+          flexBasis: "100%",
+        },
+        groupSender: {
+          fontSize: 12,
+          color: textSecondaryColor(colorScheme),
+          marginLeft: 10,
+          marginVertical: 4,
+        },
+        avatarPlaceholder: {
+          width: AvatarSizes.messageSender,
+          height: AvatarSizes.messageSender,
+        },
+        outsideContentRow: {
+          marginTop: 1,
+          flexDirection: "row",
+          justifyContent: "flex-start",
+          columnGap: 8,
+          width: "100%",
+        },
+        reactionsContainer: {
+          marginHorizontal: 8,
+          marginBottom: 8,
+        },
+        outsideReactionsContainer: {
+          flex: 1,
+        },
+      }),
+    [colorScheme]
+  );
 };

--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -279,13 +279,7 @@ const ChatMessage = ({
   const reactions = useMemo(() => getMessageReactions(message), [message]);
   const hasReactions = Object.keys(reactions).length > 0;
   const isChatMessage = !isGroupUpdated;
-  const shouldShowReactionsOutside =
-    isChatMessage && (isAttachment || isFrame || isTransaction);
-  const shouldShowReactionsInside =
-    isChatMessage && !shouldShowReactionsOutside;
-  const shouldShowOutsideContentRow =
-    isChatMessage &&
-    (isTransaction || isFrame || (isAttachment && hasReactions));
+  const shouldShowOutsideContentRow = isChatMessage && hasReactions;
 
   let messageMaxWidth: DimensionValue;
   if (isDesktop) {
@@ -476,18 +470,6 @@ const ChatMessage = ({
                       </TouchableOpacity>
                     </View>
                   )}
-                  {shouldShowReactionsInside && (
-                    <View
-                      style={
-                        hasReactions ? styles.reactionsContainer : { flex: 1 }
-                      }
-                    >
-                      <ChatMessageReactions
-                        message={message}
-                        reactions={reactions}
-                      />
-                    </View>
-                  )}
                 </ChatMessageActions>
                 {shouldShowOutsideContentRow ? (
                   <View style={styles.outsideContentRow}>
@@ -502,14 +484,12 @@ const ChatMessage = ({
                         </Text>
                       </TouchableOpacity>
                     )}
-                    {shouldShowReactionsOutside && (
-                      <View style={styles.outsideReactionsContainer}>
-                        <ChatMessageReactions
-                          message={message}
-                          reactions={reactions}
-                        />
-                      </View>
-                    )}
+                    <View style={styles.outsideReactionsContainer}>
+                      <ChatMessageReactions
+                        message={message}
+                        reactions={reactions}
+                      />
+                    </View>
                     {isFrame && message.fromMe && !hasReactions && (
                       <MessageStatus message={message} />
                     )}

--- a/components/Chat/Message/Message.tsx
+++ b/components/Chat/Message/Message.tsx
@@ -6,6 +6,7 @@ import {
   textSecondaryColor,
 } from "@styles/colors";
 import { AvatarSizes } from "@styles/sizes";
+import { useAppTheme } from "@theme/useAppTheme";
 import * as Haptics from "expo-haptics";
 import React, { ReactNode, useCallback, useMemo, useRef } from "react";
 import {
@@ -575,6 +576,8 @@ export default function CachedChatMessage({
 }
 
 const useStyles = () => {
+  const { theme } = useAppTheme();
+
   const colorScheme = useColorScheme();
   return StyleSheet.create({
     messageContainer: {
@@ -676,7 +679,8 @@ const useStyles = () => {
       height: AvatarSizes.messageSender,
     },
     outsideContentRow: {
-      marginTop: 1,
+      marginTop: theme.spacing["4xs"],
+      marginBottom: theme.spacing.xxxs,
       flexDirection: "row",
       justifyContent: "flex-start",
       columnGap: 8,

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -29,103 +29,104 @@ type RolledUpReactions = {
   userReacted: boolean;
 };
 
-function ChatMessageReactions({ message, reactions }: Props) {
-  const styles = useStyles();
-  const { theme } = useAppTheme();
-  const userAddress = useCurrentAccount();
+export const ChatMessageReactions = memo(
+  ({ message, reactions }: Props) => {
+    const styles = useStyles();
+    const { theme } = useAppTheme();
+    const userAddress = useCurrentAccount();
 
-  const reactionsList = useMemo(() => {
-    return Object.entries(reactions)
-      .flatMap(([senderAddress, reactions]) =>
-        reactions.map((reaction) => ({ ...reaction, senderAddress }))
-      )
-      .sort((r1, r2) => r1.sent - r2.sent);
-  }, [reactions]);
+    const reactionsList = useMemo(() => {
+      return Object.entries(reactions)
+        .flatMap(([senderAddress, reactions]) =>
+          reactions.map((reaction) => ({ ...reaction, senderAddress }))
+        )
+        .sort((r1, r2) => r1.sent - r2.sent);
+    }, [reactions]);
 
-  const rolledUpReactions: RolledUpReactions = useMemo(() => {
-    const counts: { [content: string]: ReactionCount } = {};
-    let totalReactions = 0;
-    let userReacted = false;
+    const rolledUpReactions: RolledUpReactions = useMemo(() => {
+      const counts: { [content: string]: ReactionCount } = {};
+      let totalReactions = 0;
+      let userReacted = false;
 
-    Object.values(reactions).forEach((reactionArray) => {
-      reactionArray.forEach((reaction) => {
-        if (!counts[reaction.content]) {
-          counts[reaction.content] = {
-            content: reaction.content,
-            count: 0,
-            userReacted: false,
-            reactors: [],
-            firstReactionTime: reaction.sent,
-          };
-        }
-        counts[reaction.content].count++;
-        counts[reaction.content].reactors.push(reaction.senderAddress);
-        if (
-          reaction.senderAddress.toLowerCase() === userAddress?.toLowerCase()
-        ) {
-          counts[reaction.content].userReacted = true;
-          userReacted = true;
-        }
-        // Keep track of the earliest reaction time for this emoji
-        counts[reaction.content].firstReactionTime = Math.min(
-          counts[reaction.content].firstReactionTime,
-          reaction.sent
-        );
-        totalReactions++;
+      Object.values(reactions).forEach((reactionArray) => {
+        reactionArray.forEach((reaction) => {
+          if (!counts[reaction.content]) {
+            counts[reaction.content] = {
+              content: reaction.content,
+              count: 0,
+              userReacted: false,
+              reactors: [],
+              firstReactionTime: reaction.sent,
+            };
+          }
+          counts[reaction.content].count++;
+          counts[reaction.content].reactors.push(reaction.senderAddress);
+          if (
+            reaction.senderAddress.toLowerCase() === userAddress?.toLowerCase()
+          ) {
+            counts[reaction.content].userReacted = true;
+            userReacted = true;
+          }
+          // Keep track of the earliest reaction time for this emoji
+          counts[reaction.content].firstReactionTime = Math.min(
+            counts[reaction.content].firstReactionTime,
+            reaction.sent
+          );
+          totalReactions++;
+        });
       });
-    });
 
-    // Sort by the number of reactors in descending order
-    const sortedReactions = Object.values(counts)
-      .sort((a, b) => b.reactors.length - a.reactors.length)
-      .slice(0, MAX_REACTION_EMOJIS_SHOWN)
-      .map((reaction) => reaction.content);
+      // Sort by the number of reactors in descending order
+      const sortedReactions = Object.values(counts)
+        .sort((a, b) => b.reactors.length - a.reactors.length)
+        .slice(0, MAX_REACTION_EMOJIS_SHOWN)
+        .map((reaction) => reaction.content);
 
-    return { emojis: sortedReactions, totalReactions, userReacted };
-  }, [reactions, userAddress]);
+      return { emojis: sortedReactions, totalReactions, userReacted };
+    }, [reactions, userAddress]);
 
-  if (reactionsList.length === 0) return null;
+    if (reactionsList.length === 0) return null;
 
-  return (
-    <View
-      style={[
-        styles.reactionsWrapper,
-        message.fromMe && { justifyContent: "flex-end" },
-      ]}
-    >
+    return (
       <View
         style={[
-          styles.reactionButton,
-          rolledUpReactions.userReacted && {
-            borderColor: theme.colors.fill.minimal,
-            backgroundColor: theme.colors.fill.minimal,
-          },
+          styles.reactionsWrapper,
+          message.fromMe && { justifyContent: "flex-end" },
         ]}
       >
-        <View style={styles.emojiContainer}>
-          {rolledUpReactions.emojis.map((emoji, index) => (
-            <Text key={index}>{emoji}</Text>
-          ))}
+        <View
+          style={[
+            styles.reactionButton,
+            rolledUpReactions.userReacted && {
+              borderColor: theme.colors.fill.minimal,
+              backgroundColor: theme.colors.fill.minimal,
+            },
+          ]}
+        >
+          <View style={styles.emojiContainer}>
+            {rolledUpReactions.emojis.map((emoji, index) => (
+              <Text key={index}>{emoji}</Text>
+            ))}
+          </View>
+          {rolledUpReactions.totalReactions > 1 && (
+            <Text style={styles.reactorCount}>
+              {rolledUpReactions.totalReactions}
+            </Text>
+          )}
         </View>
-        {rolledUpReactions.totalReactions > 1 && (
-          <Text style={styles.reactorCount}>
-            {rolledUpReactions.totalReactions}
-          </Text>
-        )}
       </View>
-    </View>
-  );
-}
-
-export default memo(ChatMessageReactions, (prevProps, nextProps) => {
-  if (prevProps.message.id !== nextProps.message.id) {
-    return false;
+    );
+  },
+  (prevProps, nextProps) => {
+    if (prevProps.message.id !== nextProps.message.id) {
+      return false;
+    }
+    if (prevProps.message.lastUpdateAt !== nextProps.message.lastUpdateAt) {
+      return false;
+    }
+    return true;
   }
-  if (prevProps.message.lastUpdateAt !== nextProps.message.lastUpdateAt) {
-    return false;
-  }
-  return true;
-});
+);
 
 const useStyles = () => {
   const { theme } = useAppTheme();

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -110,7 +110,7 @@ function ChatMessageReactions({ message, reactions }: Props) {
                 : styles.otherReactionButton,
             ]}
           >
-            <Text style={styles.emoji}>{reaction.content}</Text>
+            <Text>{reaction.content}</Text>
             <View style={styles.reactorContainer}>
               <Text style={styles.reactorCount}>{reactorCount}</Text>
             </View>
@@ -146,8 +146,8 @@ const useStyles = () => {
       alignItems: "center",
       paddingHorizontal: theme.spacing.xs,
       paddingVertical: theme.spacing.xxs,
-      borderRadius: theme.spacing.sm,
-      borderWidth: 1,
+      borderRadius: theme.borderRadius.sm,
+      borderWidth: theme.borderWidth.sm,
       borderColor: theme.colors.border.subtle,
     },
     // TODO: merge
@@ -159,15 +159,11 @@ const useStyles = () => {
     },
     // TODO: remove
     otherReactionButton: {},
-    emoji: {
-      fontSize: 14,
-    },
     reactorContainer: {
       flexDirection: "row",
       alignItems: "center",
     },
     reactorCount: {
-      fontSize: 12,
       marginLeft: theme.spacing.xxxs,
       color: theme.colors.text.secondary,
     },

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -6,7 +6,7 @@ import { StyleSheet, Text, View } from "react-native";
 
 import { MessageToDisplay } from "./Message";
 
-const MAX_REACTION_EMOJIS_SHOWN = 5;
+const MAX_REACTION_EMOJIS_SHOWN = 3;
 
 type Props = {
   message: MessageToDisplay;

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -1,35 +1,14 @@
-import Avatar from "@components/Avatar";
-import { useCurrentAccount, useProfilesStore } from "@data/store/accountsStore";
-import {
-  inversePrimaryColor,
-  textPrimaryColor,
-  primaryColor,
-} from "@styles/colors";
-import { AvatarSizes } from "@styles/sizes";
-import {
-  getPreferredAvatar,
-  getPreferredName,
-  getProfile,
-} from "@utils/profile";
+import { useCurrentAccount } from "@data/store/accountsStore";
+import { useAppTheme } from "@theme/useAppTheme";
 import {
   MessageReaction,
   addReactionToMessage,
   removeReactionFromMessage,
 } from "@utils/reactions";
 import { memo, useCallback, useMemo } from "react";
-import {
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  useColorScheme,
-  View,
-} from "react-native";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 import { MessageToDisplay } from "./Message";
-import { useAppTheme } from "../../../theme/useAppTheme";
-
-const MAX_REACTORS_TO_SHOW = 3;
-const REACTOR_OFFSET = 10;
 
 type Props = {
   message: MessageToDisplay;
@@ -47,10 +26,8 @@ type ReactionCount = {
 };
 
 function ChatMessageReactions({ message, reactions }: Props) {
-  const colorScheme = useColorScheme();
   const styles = useStyles();
   const userAddress = useCurrentAccount();
-  const profiles = useProfilesStore((state) => state.profiles);
 
   const reactionsList = useMemo(() => {
     return Object.entries(reactions)
@@ -134,56 +111,9 @@ function ChatMessageReactions({ message, reactions }: Props) {
             ]}
           >
             <Text style={styles.emoji}>{reaction.content}</Text>
-            {reactorCount <= MAX_REACTORS_TO_SHOW ? (
-              <View
-                style={[
-                  styles.reactorContainer,
-                  { marginRight: (reactorCount - 1) * -REACTOR_OFFSET },
-                ]}
-              >
-                {reaction.reactors
-                  .slice(0, MAX_REACTORS_TO_SHOW)
-                  .map((reactor, index) => (
-                    <Avatar
-                      key={reactor}
-                      uri={getPreferredAvatar(
-                        getProfile(reactor, profiles)?.socials
-                      )}
-                      name={getPreferredName(
-                        getProfile(reactor, profiles)?.socials,
-                        reactor
-                      )}
-                      size={AvatarSizes.messageReactor}
-                      invertColor={message.fromMe}
-                      style={[
-                        styles.profileImage,
-                        {
-                          left: index * -REACTOR_OFFSET,
-                          zIndex: MAX_REACTORS_TO_SHOW - (index + 1),
-                        },
-                        reaction.userReacted
-                          ? message.fromMe
-                            ? styles.myReactionToMyMessageProfileImage
-                            : styles.myReactionToOtherMessageProfileImage
-                          : styles.otherProfileImage,
-                      ]}
-                    />
-                  ))}
-              </View>
-            ) : (
-              <View style={styles.reactorContainer}>
-                <Text
-                  style={[
-                    styles.reactorCount,
-                    reaction.userReacted
-                      ? { color: inversePrimaryColor(colorScheme) }
-                      : {},
-                  ]}
-                >
-                  {reactorCount}
-                </Text>
-              </View>
-            )}
+            <View style={styles.reactorContainer}>
+              <Text style={styles.reactorCount}>{reactorCount}</Text>
+            </View>
           </TouchableOpacity>
         );
       })}
@@ -203,13 +133,13 @@ export default memo(ChatMessageReactions, (prevProps, nextProps) => {
 
 const useStyles = () => {
   const { theme } = useAppTheme();
-  const colorScheme = useColorScheme();
+
   return StyleSheet.create({
     reactionsWrapper: {
       flexDirection: "row",
       flexWrap: "wrap",
-      rowGap: theme.spacing.xxxs,
-      columnGap: theme.spacing.xxs,
+      rowGap: theme.spacing["4xs"],
+      columnGap: theme.spacing["4xs"],
     },
     reactionButton: {
       flexDirection: "row",
@@ -228,35 +158,18 @@ const useStyles = () => {
       backgroundColor: theme.colors.fill.minimal,
     },
     // TODO: remove
-    profileImage: {
-      width: 22,
-      height: 22,
-      borderRadius: 22,
-      borderWidth: 1,
-    },
-    // TODO: remove
     otherReactionButton: {},
-    // TODO: remove
-    otherProfileImage: {},
-    // TODO: remove
-    myReactionToOtherMessageProfileImage: {},
-    // TODO: remove
-    myReactionToMyMessageProfileImage: {
-      borderColor: primaryColor(colorScheme),
-    },
     emoji: {
       fontSize: 14,
-      marginHorizontal: 2,
     },
     reactorContainer: {
       flexDirection: "row",
       alignItems: "center",
-      height: 22,
     },
     reactorCount: {
       fontSize: 12,
-      marginHorizontal: 2,
-      color: textPrimaryColor(colorScheme),
+      marginLeft: theme.spacing.xxxs,
+      color: theme.colors.text.secondary,
     },
   });
 };

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -66,6 +66,7 @@ function ChatMessageReactions({ message, reactions }: Props) {
           counts[reaction.content].userReacted = true;
           userReacted = true;
         }
+        // Keep track of the earliest reaction time for this emoji
         counts[reaction.content].firstReactionTime = Math.min(
           counts[reaction.content].firstReactionTime,
           reaction.sent

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -1,8 +1,11 @@
 import { useCurrentAccount } from "@data/store/accountsStore";
+import { HStack } from "@design-system/HStack";
+import { Text } from "@design-system/Text";
+import { VStack } from "@design-system/VStack";
 import { useAppTheme } from "@theme/useAppTheme";
 import { MessageReaction } from "@utils/reactions";
 import { memo, useMemo } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet } from "react-native";
 
 import { MessageToDisplay } from "./Message";
 
@@ -88,13 +91,13 @@ export const ChatMessageReactions = memo(
     if (reactionsList.length === 0) return null;
 
     return (
-      <View
+      <HStack
         style={[
           styles.reactionsWrapper,
           message.fromMe && { justifyContent: "flex-end" },
         ]}
       >
-        <View
+        <VStack
           style={[
             styles.reactionButton,
             rolledUpReactions.userReacted && {
@@ -103,18 +106,18 @@ export const ChatMessageReactions = memo(
             },
           ]}
         >
-          <View style={styles.emojiContainer}>
+          <HStack style={styles.emojiContainer}>
             {rolledUpReactions.emojis.map((emoji, index) => (
               <Text key={index}>{emoji}</Text>
             ))}
-          </View>
+          </HStack>
           {rolledUpReactions.totalReactions > 1 && (
             <Text style={styles.reactorCount}>
               {rolledUpReactions.totalReactions}
             </Text>
           )}
-        </View>
-      </View>
+        </VStack>
+      </HStack>
     );
   },
   (prevProps, nextProps) => {

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -97,6 +97,7 @@ function ChatMessageReactions({ message, reactions }: Props) {
         style={[
           styles.reactionButton,
           rolledUpReactions.userReacted && {
+            borderColor: theme.colors.fill.minimal,
             backgroundColor: theme.colors.fill.minimal,
           },
         ]}

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -6,6 +6,8 @@ import { StyleSheet, Text, View } from "react-native";
 
 import { MessageToDisplay } from "./Message";
 
+const MAX_REACTION_EMOJIS_SHOWN = 5;
+
 type Props = {
   message: MessageToDisplay;
   reactions: {
@@ -26,8 +28,6 @@ type RolledUpReactions = {
   totalReactions: number;
   userReacted: boolean;
 };
-
-const MAX_REACTION_EMOJIS_SHOWN = 5;
 
 function ChatMessageReactions({ message, reactions }: Props) {
   const styles = useStyles();

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -27,6 +27,7 @@ import {
 } from "react-native";
 
 import { MessageToDisplay } from "./Message";
+import { useAppTheme } from "../../../theme/useAppTheme";
 
 const MAX_REACTORS_TO_SHOW = 3;
 const REACTOR_OFFSET = 10;
@@ -202,20 +203,21 @@ export default memo(ChatMessageReactions, (prevProps, nextProps) => {
 });
 
 const useStyles = () => {
+  const { theme } = useAppTheme();
   const colorScheme = useColorScheme();
   return StyleSheet.create({
     reactionsWrapper: {
       flexDirection: "row",
       flexWrap: "wrap",
-      rowGap: 4,
-      columnGap: 5,
+      rowGap: theme.spacing.xxxs,
+      columnGap: theme.spacing.xxs,
     },
     reactionButton: {
       flexDirection: "row",
       alignItems: "center",
-      paddingHorizontal: 4,
-      paddingVertical: 2,
-      borderRadius: 16,
+      paddingHorizontal: theme.spacing.xs,
+      paddingVertical: theme.spacing.xxs,
+      borderRadius: theme.spacing.md, // or change back to xs
       borderWidth: 0.25,
     },
     profileImage: {

--- a/components/Chat/Message/MessageReactions.tsx
+++ b/components/Chat/Message/MessageReactions.tsx
@@ -3,7 +3,6 @@ import { useCurrentAccount, useProfilesStore } from "@data/store/accountsStore";
 import {
   inversePrimaryColor,
   textPrimaryColor,
-  tertiaryBackgroundColor,
   primaryColor,
 } from "@styles/colors";
 import { AvatarSizes } from "@styles/sizes";
@@ -217,33 +216,31 @@ const useStyles = () => {
       alignItems: "center",
       paddingHorizontal: theme.spacing.xs,
       paddingVertical: theme.spacing.xxs,
-      borderRadius: theme.spacing.md, // or change back to xs
-      borderWidth: 0.25,
+      borderRadius: theme.spacing.sm,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
     },
+    // TODO: merge
+    myReactionToOtherMessageButton: {
+      backgroundColor: theme.colors.fill.minimal,
+    },
+    myReactionToMyMessageButton: {
+      backgroundColor: theme.colors.fill.minimal,
+    },
+    // TODO: remove
     profileImage: {
       width: 22,
       height: 22,
       borderRadius: 22,
       borderWidth: 1,
     },
-    otherReactionButton: {
-      backgroundColor: tertiaryBackgroundColor(colorScheme),
-      borderColor: tertiaryBackgroundColor(colorScheme),
-    },
-    otherProfileImage: {
-      borderColor: tertiaryBackgroundColor(colorScheme),
-    },
-    myReactionToOtherMessageButton: {
-      backgroundColor: primaryColor(colorScheme),
-      borderColor: primaryColor(colorScheme),
-    },
-    myReactionToOtherMessageProfileImage: {
-      borderColor: primaryColor(colorScheme),
-    },
-    myReactionToMyMessageButton: {
-      backgroundColor: primaryColor(colorScheme),
-      borderColor: tertiaryBackgroundColor(colorScheme),
-    },
+    // TODO: remove
+    otherReactionButton: {},
+    // TODO: remove
+    otherProfileImage: {},
+    // TODO: remove
+    myReactionToOtherMessageProfileImage: {},
+    // TODO: remove
     myReactionToMyMessageProfileImage: {
       borderColor: primaryColor(colorScheme),
     },

--- a/components/Chat/Transaction/TransactionInput.tsx
+++ b/components/Chat/Transaction/TransactionInput.tsx
@@ -2,12 +2,12 @@ import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import {
   actionSecondaryColor,
-  backgroundColor,
   dangerColor,
   itemSeparatorColor,
   textPrimaryColor,
   textSecondaryColor,
 } from "@styles/colors";
+import { useAppTheme } from "@theme/useAppTheme";
 import { Signer } from "ethers";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -356,9 +356,11 @@ export default function TransactionInput() {
 
 const useStyles = () => {
   const colorScheme = useColorScheme();
+  const { theme } = useAppTheme();
+
   return StyleSheet.create({
     transactionInputContainer: {
-      backgroundColor: backgroundColor(colorScheme),
+      backgroundColor: theme.colors.background.surface,
       flexDirection: "row",
       height: 88,
     },
@@ -371,7 +373,7 @@ const useStyles = () => {
     moneyInputContainer: {
       flexDirection: "row",
       alignSelf: "center",
-      backgroundColor: backgroundColor(colorScheme),
+      backgroundColor: theme.colors.background.surface,
       height: 50,
       marginVertical: 6,
       paddingLeft: 12,

--- a/theme/borders.ts
+++ b/theme/borders.ts
@@ -3,3 +3,5 @@ export const borderWidth = {
   md: 2,
   lg: 3,
 } as const;
+
+export type IBorderWidth = typeof borderWidth;

--- a/theme/useAppTheme.ts
+++ b/theme/useAppTheme.ts
@@ -16,6 +16,7 @@ import { StyleProp, useColorScheme } from "react-native";
 
 import { avatarSize, IAvatarSize } from "./avatar";
 import { borderRadius, IBorderRadius } from "./border-radius";
+import { borderWidth, IBorderWidth } from "./borders";
 import { colorsDark } from "./colorsDark";
 import { colorsLight, IColors } from "./colorsLight";
 import { iconSize, IIconSize } from "./icon";
@@ -30,6 +31,7 @@ export interface Theme {
   colors: IColors;
   spacing: ISpacing;
   borderRadius: IBorderRadius;
+  borderWidth: IBorderWidth;
   avatarSize: IAvatarSize;
   iconSize: IIconSize;
   typography: ITypography;
@@ -43,6 +45,7 @@ export const lightTheme: Theme = {
   spacing,
   typography,
   borderRadius,
+  borderWidth,
   avatarSize,
   iconSize,
   timing,
@@ -53,6 +56,7 @@ export const darkTheme: Theme = {
   spacing,
   typography,
   borderRadius,
+  borderWidth,
   avatarSize,
   iconSize,
   timing,


### PR DESCRIPTION
Implements rolled-up reactions

Closes #985 [Display reactions outside of the message bubble](https://github.com/ephemeraHQ/converse-app/issues/985)
Closes #937 [Rolled up reactions #937](https://github.com/ephemeraHQ/converse-app/issues/937)
Closes #667 [Fix overlapping transparent placeholder avatars in message reactions #667](https://github.com/ephemeraHQ/converse-app/issues/667)

After [Reactions detail drawer #938](https://github.com/ephemeraHQ/converse-app/issues/938) is done, tapping the rolled-up reactions button will open the reactions drawer, which will be included in another PR. For now and with this PR, tapping on the rolled-up reactions is not available, it's view-only.

Preview:
<img src="https://github.com/user-attachments/assets/3595c575-60c7-4ce7-a6b4-95f2f5bf3e2e" width=340 /><img src="https://github.com/user-attachments/assets/a46049a8-5c05-4cd0-892e-85a747a13d0e" width=340 />