### PR TITLE
fix: android backdrop shadow and initialization (snackbar)

### DIFF
--- a/components/Snackbar/Snackbar.store.ts
+++ b/components/Snackbar/Snackbar.store.ts
@@ -2,14 +2,14 @@ import { ISnackbar } from "@components/Snackbar/Snackbar.types";
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 
-export interface ISnackBarStore {
+export type ISnackBarStore = {
   snackbars: ISnackbar[];
   showSnackbar: (snackbar: ISnackbar) => void;
   clearAllSnackbars: () => void;
-}
+};
 
 export const useSnackBarStore = create<ISnackBarStore>()(
-  subscribeWithSelector((set, get) => ({
+  subscribeWithSelector((set) => ({
     snackbars: [],
     showSnackbar: (snackbar) => {
       set((state) => ({
@@ -21,3 +21,6 @@ export const useSnackBarStore = create<ISnackBarStore>()(
     },
   }))
 );
+
+// Initialize store
+useSnackBarStore.getState();

--- a/components/Snackbar/Snackbar.store.ts
+++ b/components/Snackbar/Snackbar.store.ts
@@ -2,11 +2,11 @@ import { ISnackbar } from "@components/Snackbar/Snackbar.types";
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 
-export type ISnackBarStore = {
+export interface ISnackBarStore {
   snackbars: ISnackbar[];
   showSnackbar: (snackbar: ISnackbar) => void;
   clearAllSnackbars: () => void;
-};
+}
 
 export const useSnackBarStore = create<ISnackBarStore>()(
   subscribeWithSelector((set) => ({

--- a/components/Snackbar/SnackbarBackdrop/SnackbarBackdrop.android.tsx
+++ b/components/Snackbar/SnackbarBackdrop/SnackbarBackdrop.android.tsx
@@ -10,7 +10,7 @@ import { useAnimatedStyle, withTiming } from "react-native-reanimated";
  * On Android, blur doesn't work
  */
 
-export const Backdrop = () => {
+export const SnackbarBackdrop = () => {
   const snackbars = useSnackbars();
 
   const { height: windowHeight } = useWindowDimensions();
@@ -25,6 +25,11 @@ export const Backdrop = () => {
       }),
     };
   }, [windowHeight, snackbars.length]);
+
+  // Don't render if there are no snackbars
+  if (snackbars.length === 0) {
+    return null;
+  }
 
   return (
     <AnimatedVStack

--- a/components/Snackbar/Snackbars.tsx
+++ b/components/Snackbar/Snackbars.tsx
@@ -28,7 +28,7 @@ export const Snackbars = memo(function Snackbars() {
           onDismiss={() => dismissSnackbar(snackbar.key)}
         />
       ))}
-      <SnackbarBackdrop />
+      {typeof SnackbarBackdrop !== "undefined" && <SnackbarBackdrop />}
     </>
   );
 });


### PR DESCRIPTION
- Add null check for SnackbarBackdrop component to handle platform differences
- Initialize Zustand store on import to ensure store is ready before component renders
- Fix Android backdrop shadow by only rendering when snackbars are present

Closes #1229