### PR TITLE
Silence color scheme in dev, output the log in prod only

### DIFF
--- a/theme/useAppTheme.ts
+++ b/theme/useAppTheme.ts
@@ -184,6 +184,20 @@ export const useAppTheme = (): UseAppThemeValue => {
     [themeContext]
   );
 
+  // TODO: Remove after debugging is done
+  // Light/dark mode color scheme logging
+  useEffect(() => {
+    if (!__DEV__) {
+      logger.debug("=== Theme Debug ===", {
+        systemColorScheme: Appearance.getColorScheme(),
+        platformVersion: Platform.Version,
+        themeContext: themeContext,
+        isDarkTheme: themeVariant.isDark,
+        navThemeDark: navTheme.dark,
+      });
+    }
+  }, [themeContext, themeVariant, navTheme]);
+
   const themed = useCallback(
     <T>(
       styleOrStyleFn: ThemedStyle<T> | StyleProp<T> | ThemedStyleArray<T>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a logging feature for debugging the light/dark mode color scheme in the theme management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->