### PR TITLE
fix: Fixed Reply Bubble Color

### DIFF
--- a/theme/colorsDark.ts
+++ b/theme/colorsDark.ts
@@ -7,7 +7,7 @@ export const colorsDark: IColors = {
     bubbleAccent: darkPalette.accent,
     reply: lightPalette.light96,
     nestedReply: darkPalette.alpha4,
-    nestedReplyFromMe: darkPalette.dark85,
+    nestedReplyFromMe: darkPalette.alpha4,
     received: {
       bubble: lightPalette.light15,
       reply: lightPalette.light15,


### PR DESCRIPTION
Updated dark color for nested replies
![Simulator Screenshot - iPhone 15 Pro - 2024-12-03 at 13 17 08](https://github.com/user-attachments/assets/807825c3-9d8f-45ed-b71b-412765c67170)
Fixes https://github.com/ephemeraHQ/converse-app/issues/1285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the dark theme color for the `nestedReplyFromMe` state to enhance visual clarity.
  
- **Bug Fixes**
	- Improved color representation in the dark theme configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->