### PR TITLE
feat: Conversation Context Menu Updates

### DIFF
--- a/components/ContextMenuItems.tsx
+++ b/components/ContextMenuItems.tsx
@@ -1,0 +1,87 @@
+import { VStack } from "@/design-system/VStack";
+import { memo, ReactElement } from "react";
+import { TextStyle, ViewStyle } from "react-native";
+import { ThemedStyle, useAppTheme } from "@/theme/useAppTheme";
+import { HStack } from "@/design-system/HStack";
+import { Text } from "@/design-system/Text";
+import { Pressable } from "@/design-system/Pressable";
+import { Icon } from "@/design-system/Icon/Icon";
+import { IIconName } from "@/design-system/Icon/Icon.types";
+import { iconSize } from "@/theme/icon";
+
+export type ContextMenuItem = {
+  id: string;
+  title: string;
+  action?: () => void;
+  leftView?: ReactElement;
+  rightView?: ReactElement;
+  style?: ViewStyle;
+  titleStyle?: TextStyle;
+};
+
+export type ContextMenuItemsProps = {
+  items: ContextMenuItem[];
+  containerStyle?: ViewStyle;
+};
+
+export const ContextMenuIcon = ({
+  icon,
+  color,
+}: {
+  icon: IIconName;
+  color?: string;
+}) => {
+  return <Icon icon={icon} size={iconSize.sm} color={color} />;
+};
+
+export const ContextMenuItems = memo(
+  ({ items, containerStyle }: ContextMenuItemsProps) => {
+    const { themed } = useAppTheme();
+
+    const sectionContent = items.map((i, index) => (
+      <Pressable key={i.id} onPress={i.action}>
+        <HStack
+          style={[
+            themed($defaultRowStyle),
+            index === items.length - 1 ? undefined : themed($borderStyle),
+            i.style,
+          ]}
+        >
+          {i.leftView}
+          <Text
+            preset="body"
+            style={[themed($defaultTitleStyle), i.titleStyle]}
+          >
+            {i.title}
+          </Text>
+          {i.rightView}
+        </HStack>
+      </Pressable>
+    ));
+    return (
+      <VStack style={themed($defaultContainerStyle)}>{sectionContent}</VStack>
+    );
+  }
+);
+
+const $borderStyle: ThemedStyle<ViewStyle> = (theme) => ({
+  borderBottomWidth: theme.borderWidth.sm,
+  borderBottomColor: theme.colors.border.subtle,
+});
+
+const $defaultRowStyle: ThemedStyle<ViewStyle> = (theme) => ({
+  paddingHorizontal: theme.spacing.sm,
+  paddingVertical: theme.spacing.xxs,
+  alignItems: "center",
+});
+
+const $defaultContainerStyle: ThemedStyle<ViewStyle> = (theme) => ({
+  marginVertical: theme.spacing.xxs,
+  backgroundColor: theme.colors.background.raised,
+  borderRadius: theme.borderRadius.sm,
+  width: 180,
+});
+
+const $defaultTitleStyle: ThemedStyle<TextStyle> = (theme) => ({
+  flex: 1,
+});

--- a/components/ConversationContextMenu.tsx
+++ b/components/ConversationContextMenu.tsx
@@ -6,13 +6,10 @@ import {
 } from "@/features/conversation-list/ConversationListContextMenu.store";
 import { ConversationReadOnly } from "@/screens/ConversationReadOnly";
 import { AnimatedBlurView } from "@components/AnimatedBlurView";
-import TableView from "@components/TableView/TableView";
 import {
   BACKDROP_DARK_BACKGROUND_COLOR,
   BACKDROP_LIGHT_BACKGROUND_COLOR,
-  contextMenuStyleGuide,
 } from "@design-system/ContextMenu/ContextMenu.constants";
-import { backgroundColor } from "@styles/colors";
 import { animation } from "@theme/animations";
 import { useAppTheme } from "@theme/useAppTheme";
 import { ConversationTopic } from "@xmtp/react-native-sdk";
@@ -37,6 +34,7 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
+import { ContextMenuItems } from "./ContextMenuItems";
 
 const ConversationContextMenuComponent: FC = () => {
   const isVisible = useConversationListContextMenuIsVisible();
@@ -133,7 +131,6 @@ const ConversationContextMenuComponent: FC = () => {
           >
             <View style={styles.overlay}>
               <Animated.View style={[styles.container, animatedStyle]}>
-                <View style={styles.handle} />
                 <View style={styles.previewContainer}>
                   <GestureDetector
                     gesture={Gesture.Tap().onEnd(() => {
@@ -146,7 +143,10 @@ const ConversationContextMenuComponent: FC = () => {
                   </GestureDetector>
                 </View>
                 <View style={styles.menuContainer}>
-                  <TableView style={styles.table} items={contextMenuItems} />
+                  <ContextMenuItems
+                    containerStyle={styles.table}
+                    items={contextMenuItems}
+                  />
                 </View>
               </Animated.View>
             </View>
@@ -158,8 +158,6 @@ const ConversationContextMenuComponent: FC = () => {
 };
 
 const useStyles = () => {
-  const colorScheme = useColorScheme();
-
   const { theme } = useAppTheme();
 
   return StyleSheet.create({
@@ -171,36 +169,17 @@ const useStyles = () => {
       flex: 1,
       justifyContent: "flex-end",
     },
-    handle: {
-      marginTop: 70,
-      marginBottom: 10,
-      width: 36,
-      height: 5,
-      backgroundColor: contextMenuStyleGuide.palette.secondary,
-      alignSelf: "center",
-      borderRadius: 2.5,
-    },
     previewContainer: {
       flex: 1,
-      margin: theme.spacing.md,
-      paddingBottom: contextMenuStyleGuide.spacing,
+      marginHorizontal: theme.spacing.md,
+      marginTop: theme.spacing["5xl"],
+      marginBottom: theme.spacing.zero,
+      paddingBottom: theme.spacing.xxs,
       overflow: "hidden",
       justifyContent: "flex-start",
       minHeight: 210,
-      backgroundColor: backgroundColor(colorScheme),
-      borderRadius: 16,
-    },
-    conversationName: {
-      ...contextMenuStyleGuide.typography.body,
-      fontWeight: "600",
-      marginBottom: contextMenuStyleGuide.spacing,
-    },
-    lastMessagePreview: {
-      ...contextMenuStyleGuide.typography.callout,
-      color:
-        Platform.OS === "ios"
-          ? contextMenuStyleGuide.palette.secondary
-          : contextMenuStyleGuide.palette.common.black,
+      backgroundColor: theme.colors.background.raised,
+      borderRadius: theme.borderRadius.sm,
     },
     menuContainer: {
       marginHorizontal: theme.spacing.md,
@@ -214,7 +193,7 @@ const useStyles = () => {
     table: {
       width: 180,
       backgroundColor:
-        Platform.OS === "android" ? backgroundColor(colorScheme) : undefined,
+        Platform.OS === "android" ? theme.colors.background.raised : undefined,
       borderRadius: Platform.OS === "android" ? 10 : undefined,
     },
   });

--- a/components/PinnedConversations/PinnedV3DMConversation.tsx
+++ b/components/PinnedConversations/PinnedV3DMConversation.tsx
@@ -2,7 +2,6 @@ import { PinnedConversation } from "./PinnedConversation";
 import { useCallback, useMemo } from "react";
 import { navigate } from "@utils/navigation";
 import Avatar from "@components/Avatar";
-import { AvatarSizes } from "@styles/sizes";
 import { DmWithCodecsType } from "@utils/xmtpRN/client";
 import { usePreferredInboxName } from "@hooks/usePreferredInboxName";
 import { usePreferredInboxAvatar } from "@hooks/usePreferredInboxAvatar";
@@ -18,6 +17,8 @@ import { useToggleReadStatus } from "@/features/conversation-list/hooks/useToggl
 import { useConversationIsUnread } from "@/features/conversation-list/hooks/useMessageIsUnread";
 import { useHandleDeleteDm } from "@/features/conversation-list/hooks/useHandleDeleteDm";
 import { useAppTheme } from "@/theme/useAppTheme";
+import { ContextMenuIcon, ContextMenuItem } from "../ContextMenuItems";
+import { Icon } from "@/design-system/Icon/Icon";
 
 type PinnedV3DMConversationProps = {
   conversation: DmWithCodecsType;
@@ -68,7 +69,9 @@ export const PinnedV3DMConversation = ({
     conversation,
   });
 
-  const contextMenuItems = useMemo(
+  const { theme } = useAppTheme();
+
+  const contextMenuItems: ContextMenuItem[] = useMemo(
     () => [
       {
         title: translate("unpin"),
@@ -77,6 +80,7 @@ export const PinnedV3DMConversation = ({
           closeContextMenu();
         },
         id: "pin",
+        // rightView: <ContextMenuIcon icon="menu" />,
       },
       {
         title: isUnread
@@ -87,6 +91,11 @@ export const PinnedV3DMConversation = ({
           closeContextMenu();
         },
         id: "markAsUnread",
+        rightView: (
+          <ContextMenuIcon
+            icon={isUnread ? "checkmark.message" : "message.badge"}
+          />
+        ),
       },
       {
         title: translate("delete"),
@@ -95,9 +104,22 @@ export const PinnedV3DMConversation = ({
           closeContextMenu();
         },
         id: "delete",
+        titleStyle: {
+          color: theme.colors.global.caution,
+        },
+        rightView: (
+          <ContextMenuIcon icon="trash" color={theme.colors.global.caution} />
+        ),
       },
     ],
-    [isUnread, setPinnedConversations, topic, toggleReadStatus, handleDelete]
+    [
+      isUnread,
+      theme.colors.global.caution,
+      setPinnedConversations,
+      topic,
+      toggleReadStatus,
+      handleDelete,
+    ]
   );
 
   const onLongPress = useCallback(() => {
@@ -109,8 +131,6 @@ export const PinnedV3DMConversation = ({
   }, [conversation.topic]);
 
   const title = preferredName;
-
-  const { theme } = useAppTheme();
 
   const avatarComponent = useMemo(() => {
     return (

--- a/components/PinnedConversations/PinnedV3GroupConversation.tsx
+++ b/components/PinnedConversations/PinnedV3GroupConversation.tsx
@@ -16,6 +16,7 @@ import { useHandleDeleteGroup } from "@/features/conversation-list/hooks/useHand
 import { useToggleReadStatus } from "@/features/conversation-list/hooks/useToggleReadStatus";
 import { useConversationIsUnread } from "@/features/conversation-list/hooks/useMessageIsUnread";
 import { useAppTheme } from "@/theme/useAppTheme";
+import { ContextMenuIcon, ContextMenuItem } from "../ContextMenuItems";
 
 type PinnedV3GroupConversationProps = {
   group: GroupWithCodecsType;
@@ -43,6 +44,8 @@ export const PinnedV3GroupConversation = ({
 
   const timestamp = group?.lastMessage?.sentNs ?? 0;
 
+  const { theme } = useAppTheme();
+
   const isUnread = useConversationIsUnread({
     topic,
     lastMessage: group.lastMessage,
@@ -58,7 +61,7 @@ export const PinnedV3GroupConversation = ({
 
   const handleDelete = useHandleDeleteGroup(group);
 
-  const contextMenuItems = useMemo(() => {
+  const contextMenuItems: ContextMenuItem[] = useMemo(() => {
     return [
       {
         title: translate("unpin"),
@@ -77,6 +80,11 @@ export const PinnedV3GroupConversation = ({
           closeContextMenu();
         },
         id: "markAsUnread",
+        rightView: (
+          <ContextMenuIcon
+            icon={isUnread ? "checkmark.message" : "message.badge"}
+          />
+        ),
       },
       {
         title: translate("delete"),
@@ -85,9 +93,22 @@ export const PinnedV3GroupConversation = ({
           closeContextMenu();
         },
         id: "delete",
+        titleStyle: {
+          color: theme.colors.global.caution,
+        },
+        rightView: (
+          <ContextMenuIcon icon="trash" color={theme.colors.global.caution} />
+        ),
       },
     ];
-  }, [handleDelete, isUnread, setPinnedConversations, toggleReadStatus, topic]);
+  }, [
+    handleDelete,
+    isUnread,
+    setPinnedConversations,
+    theme.colors.global.caution,
+    toggleReadStatus,
+    topic,
+  ]);
 
   const onLongPress = useCallback(() => {
     setConversationListContextMenuConversationData(
@@ -101,8 +122,6 @@ export const PinnedV3GroupConversation = ({
   }, [group.topic]);
 
   const title = group?.name;
-
-  const { theme } = useAppTheme();
 
   const avatarComponent = useMemo(() => {
     if (group?.imageUrlSquare) {

--- a/components/V3DMListItem.tsx
+++ b/components/V3DMListItem.tsx
@@ -25,6 +25,8 @@ import {
   setConversationListContextMenuConversationData,
 } from "@/features/conversation-list/ConversationListContextMenu.store";
 import { useHandleDeleteDm } from "@/features/conversation-list/hooks/useHandleDeleteDm";
+import { ContextMenuIcon, ContextMenuItem } from "./ContextMenuItems";
+import { useAppTheme } from "@/theme/useAppTheme";
 
 type V3DMListItemProps = {
   conversation: DmWithCodecsType;
@@ -75,6 +77,8 @@ export const V3DMListItem = ({ conversation }: V3DMListItemProps) => {
     isUnread,
   });
 
+  const { theme } = useAppTheme();
+
   const messageText = useMessageText(conversation.lastMessage);
   const preferredName = usePreferredInboxName(peer);
   const avatarUri = usePreferredInboxAvatar(peer);
@@ -95,7 +99,7 @@ export const V3DMListItem = ({ conversation }: V3DMListItemProps) => {
     resetConversationListContextMenuStore();
   }, []);
 
-  const contextMenuItems = useMemo(
+  const contextMenuItems: ContextMenuItem[] = useMemo(
     () => [
       {
         title: translate("pin"),
@@ -114,6 +118,11 @@ export const V3DMListItem = ({ conversation }: V3DMListItemProps) => {
           closeContextMenu();
         },
         id: "markAsUnread",
+        rightView: (
+          <ContextMenuIcon
+            icon={isUnread ? "checkmark.message" : "message.badge"}
+          />
+        ),
       },
       {
         title: translate("delete"),
@@ -122,15 +131,22 @@ export const V3DMListItem = ({ conversation }: V3DMListItemProps) => {
           closeContextMenu();
         },
         id: "delete",
+        titleStyle: {
+          color: theme.colors.global.caution,
+        },
+        rightView: (
+          <ContextMenuIcon icon="trash" color={theme.colors.global.caution} />
+        ),
       },
     ],
     [
-      topic,
-      setPinnedConversations,
-      handleDelete,
-      closeContextMenu,
       isUnread,
+      theme.colors.global.caution,
+      setPinnedConversations,
+      topic,
+      closeContextMenu,
       toggleReadStatus,
+      handleDelete,
     ]
   );
 

--- a/components/V3GroupConversationListItem.tsx
+++ b/components/V3GroupConversationListItem.tsx
@@ -34,6 +34,8 @@ import {
   resetConversationListContextMenuStore,
   setConversationListContextMenuConversationData,
 } from "@/features/conversation-list/ConversationListContextMenu.store";
+import { ContextMenuIcon, ContextMenuItem } from "./ContextMenuItems";
+import { useAppTheme } from "@/theme/useAppTheme";
 
 type V3GroupConversationListItemProps = {
   group: GroupWithCodecsType;
@@ -61,6 +63,7 @@ const useData = ({ group }: UseDataProps) => {
   );
 
   const topic = group?.topic;
+  const { theme } = useAppTheme();
   const timestamp = group?.lastMessage?.sentNs ?? 0;
 
   const isUnread = useConversationIsUnread({
@@ -191,7 +194,7 @@ const useData = ({ group }: UseDataProps) => {
     );
   }, [colorScheme, currentAccount, group, setInboxIdPeerStatus]);
 
-  const contextMenuItems = useMemo(
+  const contextMenuItems: ContextMenuItem[] = useMemo(
     () => [
       {
         title: translate("pin"),
@@ -210,6 +213,11 @@ const useData = ({ group }: UseDataProps) => {
           closeContextMenu();
         },
         id: "markAsUnread",
+        rightView: (
+          <ContextMenuIcon
+            icon={isUnread ? "checkmark.message" : "message.badge"}
+          />
+        ),
       },
       {
         title: translate("delete"),
@@ -218,9 +226,22 @@ const useData = ({ group }: UseDataProps) => {
           closeContextMenu();
         },
         id: "delete",
+        titleStyle: {
+          color: theme.colors.global.caution,
+        },
+        rightView: (
+          <ContextMenuIcon icon="trash" color={theme.colors.global.caution} />
+        ),
       },
     ],
-    [topic, setPinnedConversations, handleDelete, isUnread, toggleReadStatus]
+    [
+      isUnread,
+      theme.colors.global.caution,
+      setPinnedConversations,
+      topic,
+      toggleReadStatus,
+      handleDelete,
+    ]
   );
 
   const showContextMenu = useCallback(() => {

--- a/features/conversation-list/ConversationListContextMenu.store.ts
+++ b/features/conversation-list/ConversationListContextMenu.store.ts
@@ -1,10 +1,11 @@
 import { create } from "zustand";
 import { ConversationTopic } from "@xmtp/react-native-sdk";
 import { TableViewItemType } from "@/components/TableView/TableView";
+import { ContextMenuItem } from "@/components/ContextMenuItems";
 
 type IConversationListContextMenuState = {
   conversationTopic: ConversationTopic | undefined;
-  menuItems: TableViewItemType[];
+  menuItems: ContextMenuItem[];
 };
 
 const initialMessageReactionsState: IConversationListContextMenuState = {
@@ -27,7 +28,7 @@ export const resetConversationListContextMenuStore = () => {
 
 export const setConversationListContextMenuConversationData = (
   conversationTopic: ConversationTopic,
-  menuItems: TableViewItemType[]
+  menuItems: ContextMenuItem[]
 ) => {
   useConversationListContextMenuStore.setState({
     conversationTopic,


### PR DESCRIPTION
Updated conversation List items to have icons
Added new context menu items component to match mocks easier and not have platform specific logic

![Simulator Screenshot - iPhone 15 Pro - 2024-12-05 at 18 22 40](https://github.com/user-attachments/assets/a65a41e5-f0a1-48c9-bcfa-3b0b3af1729b)
![Simulator Screenshot - iPhone 15 Pro - 2024-12-05 at 18 22 35](https://github.com/user-attachments/assets/4e44c0a8-a7f3-4d58-aefe-304bdc36b7ca)
![Simulator Screenshot - iPhone 15 Pro - 2024-12-05 at 18 22 32](https://github.com/user-attachments/assets/bc391306-a9be-4fbb-b4e7-dfdc10c8f6cc)
![Simulator Screenshot - iPhone 15 Pro - 2024-12-05 at 18 22 27](https://github.com/user-attachments/assets/101d79dd-6312-4bd3-aee2-017d5393c6b4)
![Simulator Screenshot - iPhone 15 Pro - 2024-12-05 at 18 22 23](https://github.com/user-attachments/assets/83ffdb1b-ff23-4606-99db-2b570e63eb26)
