### PR TITLE
Fix reply message profile display

### DIFF
--- a/components/Chat/Message/message-content-types/message-reply.tsx
+++ b/components/Chat/Message/message-content-types/message-reply.tsx
@@ -19,9 +19,15 @@ import { useQuery } from "@tanstack/react-query";
 import { useAppTheme } from "@theme/useAppTheme";
 import { sentryTrackError } from "@utils/sentry";
 import { getReadableProfile } from "@utils/str";
-import { DecodedMessage, MessageId, ReplyCodec } from "@xmtp/react-native-sdk";
+import {
+  DecodedMessage,
+  InboxId,
+  MessageId,
+  ReplyCodec,
+} from "@xmtp/react-native-sdk";
 import { memo } from "react";
 import { getCurrentConversationMessages } from "../../../../features/conversation/conversation-service";
+import { usePreferredInboxName } from "@/hooks/usePreferredInboxName";
 
 export const MessageReply = memo(function MessageReply(props: {
   message: DecodedMessage<[ReplyCodec]>;
@@ -116,9 +122,9 @@ const MessageReplyReference = memo(function MessageReplyReference(props: {
   const replyMessageReference =
     useConversationMessageForReplyMessage(referenceMessageId);
 
-  const readableProfile = replyMessageReference
-    ? getReadableProfile(currentAccount, replyMessageReference.senderAddress)
-    : null;
+  const inboxName = usePreferredInboxName(
+    replyMessageReference?.senderAddress as InboxId
+  );
 
   return (
     <VStack
@@ -151,7 +157,7 @@ const MessageReplyReference = memo(function MessageReplyReference(props: {
           }
         />
         <Text preset="smaller" color="secondary" inverted={fromMe}>
-          {readableProfile}
+          {inboxName}
         </Text>
       </HStack>
       {!!replyMessageReference && (

--- a/features/conversation/composer/composer.tsx
+++ b/features/conversation/composer/composer.tsx
@@ -25,6 +25,7 @@ import { sentryTrackError } from "@utils/sentry";
 import { DecodedMessageWithCodecsType } from "@utils/xmtpRN/client";
 import {
   DecodedMessage,
+  InboxId,
   MessageId,
   RemoteAttachmentCodec,
   RemoteAttachmentContent,
@@ -64,6 +65,7 @@ import {
 } from "../conversation-service";
 import { AddAttachmentButton } from "./add-attachment-button";
 import { ISendMessageParams } from "@/features/conversation/conversation-context";
+import { usePreferredInboxName } from "@/hooks/usePreferredInboxName";
 
 export type IComposerSendArgs = ISendMessageParams;
 
@@ -230,15 +232,15 @@ const ReplyPreview = memo(function ReplyPreview() {
     ? getConversationMessages(currentAccount, topic!)?.byId[replyingToMessageId]
     : undefined;
 
-  const readableProfile = replyMessage
-    ? getReadableProfile(currentAccount, replyMessage?.senderAddress)
-    : null;
+  const inboxName = usePreferredInboxName(
+    replyMessage?.senderAddress as InboxId
+  );
 
   const replyingTo = replyMessage
     ? replyMessage.senderAddress === currentAccountInboxId
       ? `Replying to you`
-      : readableProfile
-        ? `Replying to ${readableProfile}`
+      : inboxName
+        ? `Replying to ${inboxName}`
         : "Replying"
     : "";
 


### PR DESCRIPTION
Changes:

- Updated reply message preview to use the `usePreferredInboxName` hook instead of `readableProfile`.  
- Now correctly resolves InboxId to human-readable names.
- Maintains existing fallback behavior with "Replying" text if no profile name is found

Fixes #1308

<img src="https://github.com/user-attachments/assets/fc7c2329-f148-43b1-97bc-ce4ef3820057" width="350" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved display of sender information in reply messages by integrating inbox names.
	- Enhanced reply context in the message composer for clearer user experience.

- **Bug Fixes**
	- Streamlined logic for determining displayed text in reply previews, ensuring relevant information is shown.

- **Documentation**
	- Updated imports to reflect new hooks and types related to inbox handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->