### PR TITLE
fix: Streaming New Messages on Created Conversations

### DIFF
--- a/features/conversation-requests-list/useRequestItems.tsx
+++ b/features/conversation-requests-list/useRequestItems.tsx
@@ -1,10 +1,13 @@
 import { useV3RequestItems } from "./useV3RequestItems";
 
 export const useRequestItems = () => {
-  const { likelyNotSpam, likelySpam } = useV3RequestItems();
+  const { likelyNotSpam, likelySpam, isRefetching, refetch } =
+    useV3RequestItems();
 
   return {
     likelyNotSpam,
     likelySpam,
+    isRefetching,
+    refetch,
   };
 };

--- a/screens/Accounts/Accounts.tsx
+++ b/screens/Accounts/Accounts.tsx
@@ -11,21 +11,18 @@ import AccountSettingsButton from "../../components/AccountSettingsButton";
 import TableView from "../../components/TableView/TableView";
 import { TableViewPicto } from "../../components/TableView/TableViewImage";
 import {
-  useAccountsList,
   useAccountsStore,
   useErroredAccountsMap,
 } from "../../data/store/accountsStore";
 import { useRouter } from "../../navigation/useNavigation";
 import { useAccountsProfiles } from "../../utils/str";
 import { NavigationParamList } from "../Navigation/Navigation";
-import { shortAddress } from "@utils/strings/shortAddress";
 import { translate } from "@/i18n";
 
 export default function Accounts(
   props: NativeStackScreenProps<NavigationParamList, "Accounts">
 ) {
   const styles = useStyles();
-  const accounts = useAccountsList();
   const erroredAccounts = useErroredAccountsMap();
   const accountsProfiles = useAccountsProfiles();
   const setCurrentAccount = useAccountsStore((s) => s.setCurrentAccount);
@@ -40,9 +37,9 @@ export default function Accounts(
       style={styles.accounts}
     >
       <TableView
-        items={accounts.map((a) => ({
+        items={accountsProfiles.map((a) => ({
           id: a,
-          title: accountsProfiles[a] || shortAddress(a),
+          title: a,
           action: () => {
             setCurrentAccount(a, false);
             router.navigate("Chats");

--- a/screens/Navigation/ConversationRequestsListNav.ios.tsx
+++ b/screens/Navigation/ConversationRequestsListNav.ios.tsx
@@ -33,7 +33,8 @@ export default function ConversationRequestsListNav() {
   const [clearingAll, setClearingAll] = useState(false);
 
   const [selectedSegment, setSelectedSegment] = useState(0);
-  const { likelySpam, likelyNotSpam } = useRequestItems();
+  const { likelySpam, likelyNotSpam, isRefetching, refetch } =
+    useRequestItems();
 
   const styles = useStyles();
 
@@ -171,7 +172,12 @@ export default function ConversationRequestsListNav() {
             {translate("hidden_requests_warn")}
           </Text>
         )}
-        <ConversationFlashList {...navigationProps} items={itemsToShow} />
+        <ConversationFlashList
+          {...navigationProps}
+          isRefetching={isRefetching}
+          refetch={refetch}
+          items={itemsToShow}
+        />
       </>
     );
   };

--- a/screens/Navigation/ConversationRequestsListNav.tsx
+++ b/screens/Navigation/ConversationRequestsListNav.tsx
@@ -36,7 +36,8 @@ export default function ConversationRequestsListNav() {
   const [clearingAll, setClearingAll] = useState(false);
 
   const [isSpamToggleEnabled, setIsSpamToggleEnabled] = useState(false);
-  const { likelySpam, likelyNotSpam } = useRequestItems();
+  const { likelySpam, likelyNotSpam, isRefetching, refetch } =
+    useRequestItems();
 
   const styles = useStyles();
 
@@ -160,7 +161,12 @@ export default function ConversationRequestsListNav() {
           <>
             <GestureHandlerRootView style={styles.root}>
               <View style={styles.container}>
-                <ConversationFlashList {...navigationProps} items={items} />
+                <ConversationFlashList
+                  {...navigationProps}
+                  isRefetching={isRefetching}
+                  refetch={refetch}
+                  items={items}
+                />
               </View>
             </GestureHandlerRootView>
           </>

--- a/utils/str.ts
+++ b/utils/str.ts
@@ -1,12 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Dimensions, PixelRatio, TextInput } from "react-native";
 
-import logger from "./logger";
-import { getProfilesStore, useAccountsList } from "../data/store/accountsStore";
-import { ProfilesStoreType } from "../data/store/profilesStore";
-import { getProfile } from "./profile/getProfile";
+import { useAccountsList } from "../data/store/accountsStore";
 import { getPreferredName } from "./profile/getPreferredName";
 import { getProfileSocialsQueryData } from "@/queries/useProfileSocialsQuery";
+import { usePreferredNames } from "@/hooks/usePreferredNames";
 
 const { humanize } = require("../vendor/humanhash");
 
@@ -66,40 +64,10 @@ export const getReadableProfile = (account: string, address: string) => {
 
 export const useAccountsProfiles = () => {
   const accounts = useAccountsList();
-  const [accountsProfiles, setAccountsProfiles] = useState<{
-    [account: string]: string;
-  }>({});
 
-  const handleAccount = useCallback(
-    (account: string, state: ProfilesStoreType) => {
-      const socials = getProfile(account, state.profiles)?.socials;
-      const readableProfile = getPreferredName(socials, account);
+  const accountNames = usePreferredNames(accounts);
 
-      if (accountsProfiles[account] !== readableProfile) {
-        setAccountsProfiles((s) => ({
-          ...s,
-          [account]: readableProfile,
-        }));
-      }
-    },
-    [accountsProfiles]
-  );
-
-  useEffect(() => {
-    accounts.forEach((account) => {
-      try {
-        const currentState = getProfilesStore(account).getState();
-        handleAccount(account, currentState);
-        getProfilesStore(account).subscribe((state) => {
-          handleAccount(account, state);
-        });
-      } catch (e) {
-        logger.error(e);
-      }
-    });
-  }, [accounts, handleAccount]);
-
-  return accountsProfiles;
+  return accountNames;
 };
 
 export const strByteSize = (str: string) => new Blob([str]).size;


### PR DESCRIPTION
Restart message stream when creating a new conversation Updated Accounts list to use query
Added pull to refresh for request list

Workaround for https://github.com/xmtp/xmtp-react-native/issues/560

Fixes https://github.com/ephemeraHQ/converse-app/issues/1335
Fixes https://github.com/ephemeraHQ/converse-app/issues/1334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data fetching capabilities in the conversation requests list.
	- Improved handling of account profiles by utilizing a preferred names hook.
	- Introduced message streaming management for new conversations and groups.

- **Bug Fixes**
	- Addressed case sensitivity issues in account identifier handling.

- **Refactor**
	- Simplified account data management in the Accounts component.
	- Streamlined the use of hooks for account profiles, reducing complexity.

- **Chores**
	- Removed obsolete imports and code for better clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->