### PR TITLE
Fix conversation screen header styling

### DIFF
--- a/components/Conversation/ConversationTitleDumb.tsx
+++ b/components/Conversation/ConversationTitleDumb.tsx
@@ -7,9 +7,8 @@ import {
   useColorScheme,
 } from "react-native";
 import { getTitleFontScale } from "@utils/str";
-import { AnimatedHStack } from "@design-system/HStack";
-import { animation } from "@theme/animations";
 import { VStack } from "@/design-system/VStack";
+import { HStack } from "@design-system/HStack";
 
 type ConversationTitleDumbProps = {
   title?: string;
@@ -29,10 +28,7 @@ export function ConversationTitleDumb({
   const styles = useStyles();
 
   return (
-    <AnimatedHStack
-      style={styles.container}
-      entering={animation.fadeInUpSlow()}
-    >
+    <HStack style={styles.container}>
       <TouchableOpacity
         onLongPress={onLongPress}
         onPress={onPress}
@@ -46,7 +42,7 @@ export function ConversationTitleDumb({
           {subtitle}
         </VStack>
       </TouchableOpacity>
-    </AnimatedHStack>
+    </HStack>
   );
 }
 

--- a/components/Screen/ScreenComp/Screen.props.tsx
+++ b/components/Screen/ScreenComp/Screen.props.tsx
@@ -1,4 +1,3 @@
-import { StatusBarProps } from "expo-status-bar";
 import { ScrollViewProps, StyleProp, ViewStyle } from "react-native";
 
 import { ExtendedEdge } from "./Screen.helpers";
@@ -24,14 +23,6 @@ type BaseScreenProps = {
    * Background color
    */
   backgroundColor?: string;
-  /**
-   * Status bar setting. Defaults to dark.
-   */
-  statusBarStyle?: "light" | "dark";
-  /**
-   * Pass any additional props directly to the StatusBar component.
-   */
-  StatusBarProps?: StatusBarProps;
   /**
    * Pass any additional props directly to the KeyboardAvoidingView component.
    */

--- a/components/Screen/ScreenComp/Screen.tsx
+++ b/components/Screen/ScreenComp/Screen.tsx
@@ -1,5 +1,4 @@
 import { useScrollToTop } from "@react-navigation/native";
-import { StatusBar } from "expo-status-bar";
 import React, { useRef } from "react";
 import { ScrollView, View, ViewStyle } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
@@ -81,23 +80,18 @@ function ScreenWithScrolling(props: IScreenProps) {
 /**
  * Represents a screen component that provides a consistent layout and behavior for different screen presets.
  * The `Screen` component can be used with different presets such as "fixed", "scroll", or "auto".
- * It handles safe area insets, status bar settings, keyboard avoiding behavior, and scrollability based on the preset.
+ * It handles safe area insets, keyboard avoiding behavior, and scrollability based on the preset.
  * @see [Documentation and Examples]{@link https://docs.infinite.red/ignite-cli/boilerplate/app/components/Screen/}
  */
 export function Screen(props: IScreenProps) {
   const { theme } = useAppTheme();
-  const {
-    backgroundColor = theme.colors.background.surface,
-    safeAreaEdges,
-    StatusBarProps,
-    statusBarStyle = "dark",
-  } = props;
+  const { backgroundColor = theme.colors.background.surface, safeAreaEdges } =
+    props;
 
   const $containerInsets = useSafeAreaInsetsStyle(safeAreaEdges);
 
   return (
     <VStack style={[$containerStyle, { backgroundColor }, $containerInsets]}>
-      <StatusBar style={statusBarStyle} {...StatusBarProps} />
       {isNonScrolling(props.preset) ? (
         <ScreenWithoutScrolling {...props} />
       ) : (

--- a/screens/Navigation/ConversationNav.tsx
+++ b/screens/Navigation/ConversationNav.tsx
@@ -1,16 +1,14 @@
 import { NavigationProp } from "@react-navigation/native";
-import { textPrimaryColor } from "@styles/colors";
-import { PictoSizes } from "@styles/sizes";
 import { useCallback } from "react";
 import {
   Platform,
   StyleSheet,
   TouchableOpacity,
-  useColorScheme,
+  ViewStyle,
 } from "react-native";
 import { StackAnimationTypes } from "react-native-screens";
 
-import Picto from "../../components/Picto/Picto";
+import { Icon } from "@design-system/Icon/Icon";
 import Conversation from "../Conversation";
 import {
   NativeStack,
@@ -18,6 +16,7 @@ import {
   navigationAnimation,
 } from "./Navigation";
 import type { ConversationTopic } from "@xmtp/react-native-sdk";
+import { useAppTheme } from "@theme/useAppTheme";
 
 export type ConversationNavParams = {
   topic?: ConversationTopic;
@@ -39,13 +38,19 @@ export const ConversationScreenConfig = {
 export default function ConversationNav(
   routeParams?: ConversationNavParams | undefined
 ) {
-  const colorScheme = useColorScheme();
+  const { theme, themed } = useAppTheme();
 
   const navigationOptions = useCallback(
     ({ navigation }: { navigation: NavigationProp<NavigationParamList> }) => ({
       headerShadowVisible: false,
       animation: navigationAnimation as StackAnimationTypes,
       title: "",
+      headerStyle: {
+        backgroundColor: theme.colors.background.surface,
+        height: Platform.OS === "ios" ? 44 : undefined,
+        borderBottomWidth: 0.5,
+        borderBottomColor: theme.colors.border.subtle,
+      } as any,
       headerLeft: () => {
         const handleBack = () => {
           navigation.canGoBack() && navigation.goBack();
@@ -53,19 +58,19 @@ export default function ConversationNav(
         return (
           <TouchableOpacity
             onPress={handleBack}
-            style={styles.iconContainer}
+            style={themed($iconContainer)}
             hitSlop={{ top: 20, bottom: 20, left: 20, right: 10 }}
           >
-            <Picto
-              picto="chevron.left"
-              size={PictoSizes.conversationNav}
-              color={textPrimaryColor(colorScheme)}
+            <Icon
+              icon="chevron.left"
+              size={theme.iconSize.md}
+              color={theme.colors.text.primary}
             />
           </TouchableOpacity>
         );
       },
     }),
-    [colorScheme]
+    [theme, themed]
   );
   return (
     <NativeStack.Screen name="Conversation" options={navigationOptions}>
@@ -76,10 +81,8 @@ export default function ConversationNav(
   );
 }
 
-const styles = StyleSheet.create({
-  iconContainer: {
-    height: 40,
-    justifyContent: "center",
-    paddingRight: Platform.OS === "ios" ? 16 : 30,
-  },
-});
+const $iconContainer: ViewStyle = {
+  height: 40,
+  justifyContent: "center",
+  paddingRight: Platform.OS === "ios" ? 16 : 30,
+};

--- a/screens/Navigation/ConversationNav.tsx
+++ b/screens/Navigation/ConversationNav.tsx
@@ -47,9 +47,6 @@ export default function ConversationNav(
       title: "",
       headerStyle: {
         backgroundColor: theme.colors.background.surface,
-        height: Platform.OS === "ios" ? 44 : undefined,
-        borderBottomWidth: 0.5,
-        borderBottomColor: theme.colors.border.subtle,
       } as any,
       headerLeft: () => {
         const handleBack = () => {


### PR DESCRIPTION
### Header Styling

- Migrated to new theme system
- Replaced deprecated `Picto` with `Icon` from design system with icon size to `md`
- Removed fade-in-up animation

### Status Bar

- Removed status bar handling from `<Screen>` component
- Let the system handle status bar style based on navigation theme
- This fixes the black-on-black status bar issue in dark mode

### Testing

- Verified header styling matches conversation list
- Checked dark/light mode transitions
- Tested status bar visibility in both modes

<img src="https://github.com/user-attachments/assets/5e1ff57c-1e94-4257-8a60-fbe2b586f323" width="350" />

<img src="https://github.com/user-attachments/assets/967a3d37-b81d-42d2-a60a-22311aac419a" width="350" />

Fixes #1327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined the `ConversationNav` component with enhanced theming integration.
	- Updated the `Screen` component to simplify status bar management.
  
- **Bug Fixes**
	- Removed unnecessary status bar properties from the `BaseScreenProps`, improving component clarity.

- **Documentation**
	- Updated documentation for the `Screen` component to reflect changes in status bar handling.

- **Refactor**
	- Replaced `AnimatedHStack` with `HStack` in the `ConversationTitleDumb` component, removing animation effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->