### PR TITLE
Group invite deep link fix

### DIFF
--- a/features/GroupInvites/joinGroup/JoinGroupNavigation.tsx
+++ b/features/GroupInvites/joinGroup/JoinGroupNavigation.tsx
@@ -10,6 +10,7 @@ import {
 import { Platform, useColorScheme } from "react-native";
 
 import { JoinGroupScreen } from "./JoinGroup.screen";
+import { stackGroupScreenOptions } from "@/screens/Navigation/navHelpers";
 
 export type JoinGroupNavigationParams = {
   groupInviteId: string;
@@ -21,20 +22,23 @@ export const JoinGroupScreenConfig = {
 
 export function JoinGroupNavigation() {
   const colorScheme = useColorScheme();
+
   return (
-    <NativeStack.Screen
-      name="GroupInvite"
-      component={JoinGroupScreen}
-      options={({ route }) => ({
-        headerShadowVisible: false,
-        headerTitle: "",
-        headerTintColor:
-          Platform.OS === "android"
-            ? textSecondaryColor(colorScheme)
-            : textPrimaryColor(colorScheme),
-        animation: navigationAnimation,
-        headerTitleStyle: headerTitleStyle(colorScheme),
-      })}
-    />
+    <NativeStack.Group screenOptions={stackGroupScreenOptions(colorScheme)}>
+      <NativeStack.Screen
+        name="GroupInvite"
+        component={JoinGroupScreen}
+        options={({ route }) => ({
+          headerShadowVisible: false,
+          headerTitle: "",
+          headerTintColor:
+            Platform.OS === "android"
+              ? textSecondaryColor(colorScheme)
+              : textPrimaryColor(colorScheme),
+          animation: navigationAnimation,
+          headerTitleStyle: headerTitleStyle(colorScheme),
+        })}
+      />
+    </NativeStack.Group>
   );
 }

--- a/features/GroupInvites/joinGroup/joinGroup.machine.ts
+++ b/features/GroupInvites/joinGroup/joinGroup.machine.ts
@@ -233,18 +233,27 @@ export const joinGroupMachineLogic = setup({
 
       const invitedConversation: ConversationWithCodecsType | undefined =
         conversation.byId[invitedConversationId];
+
+      if (!invitedConversation) {
+        return false;
+      }
+
       // if this conversation is a DM, we assume the user has membership
       // if this conversation is a Group, we check isGroupActive === true
-      if (invitedConversation.version === ConversationVersion.DM) {
+      if (invitedConversation?.version === ConversationVersion.DM) {
         return true;
       }
 
-      const userHasBeenBlocked =
-        invitedConversation?.version === ConversationVersion.GROUP &&
-        invitedConversation?.isGroupActive === false;
+      // If version is undefined, treat it as not being in the group
+      if (!invitedConversation.version) {
+        return false;
+      }
 
-      const userIsInGroup =
-        !userHasBeenBlocked && invitedConversation !== undefined;
+      const userHasBeenBlocked =
+        invitedConversation.version === ConversationVersion.GROUP &&
+        invitedConversation.isGroupActive === false;
+
+      const userIsInGroup = !userHasBeenBlocked;
       return userIsInGroup;
     },
   },

--- a/screens/Navigation/navHelpers.ts
+++ b/screens/Navigation/navHelpers.ts
@@ -56,6 +56,28 @@ export const getConverseStateFromPath =
     if (pathForState?.startsWith("/")) {
       pathForState = pathForState.slice(1);
     }
+
+    // Handle group invite links
+    if (pathForState?.startsWith("group-invite")) {
+      const url = new URL(`https://${config.websiteDomain}/${pathForState}`);
+      const params = new URLSearchParams(url.search);
+      const inviteId = params.get("inviteId") || url.pathname.split("/")[1];
+      if (inviteId) {
+        return {
+          routes: [
+            {
+              name: "GroupInvite",
+              params: {
+                groupInviteId: inviteId,
+              },
+            },
+          ],
+        };
+      }
+    }
+
+    // dm method must link to the Conversation Screen as well
+    // but prefilling the parameters
     if (pathForState?.startsWith("dm?peer=")) {
       const params = new URLSearchParams(pathForState.slice(3));
       pathForState = handleConversationLink({
@@ -88,9 +110,6 @@ export const getConverseStateFromPath =
         groupId,
         text: params.get("text"),
       });
-    } else if (pathForState?.startsWith("groupInvite")) {
-      // TODO: Remove this once enough users have updated (September 30, 2024)
-      pathForState = pathForState.replace("groupInvite", "group-invite");
     } else if (pathForState?.startsWith("?text=")) {
       const url = new URL(`https://${config.websiteDomain}/${pathForState}`);
       const params = new URLSearchParams(url.search);

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -58,14 +58,25 @@ const isDMLink = (url: string) => {
 };
 
 const isGroupInviteLink = (url: string) => {
+  // First check if it's a universal link
   for (const prefix of config.universalLinks) {
     if (url.startsWith(prefix)) {
       const path = url.slice(prefix.length);
       if (path.toLowerCase().startsWith("group-invite/")) {
+        logger.debug("[Navigation] Found group invite universal link:", path);
         return true;
       }
     }
   }
+
+  // Then check for deep link format with scheme
+  if (url.includes("group-invite")) {
+    logger.debug("[Navigation] Found group invite deep link:", url);
+    return true;
+  }
+
+  logger.debug("[Navigation] Not a group invite link:", url);
+  return false;
 };
 
 const isGroupLink = (url: string) => {
@@ -77,20 +88,30 @@ const isGroupLink = (url: string) => {
       }
     }
   }
+  return false;
 };
 
 const originalOpenURL = RNLinking.openURL.bind(RNLinking);
 RNLinking.openURL = (url: string) => {
-  // If the URL is a DM link, open it inside the app
-  // as a deeplink, not the browser
-  if (isDMLink(url)) {
-    return originalOpenURL(getSchemedURLFromUniversalURL(url));
+  logger.debug("[Navigation] Processing URL:", url);
+
+  try {
+    if (isDMLink(url)) {
+      logger.debug("[Navigation] Handling DM link");
+      return originalOpenURL(getSchemedURLFromUniversalURL(url));
+    }
+    if (isGroupInviteLink(url)) {
+      logger.debug("[Navigation] Handling group invite link");
+      return originalOpenURL(getSchemedURLFromUniversalURL(url));
+    }
+    if (isGroupLink(url)) {
+      logger.debug("[Navigation] Handling group link");
+      return originalOpenURL(getSchemedURLFromUniversalURL(url));
+    }
+    logger.debug("[Navigation] Handling default link");
+    return originalOpenURL(url);
+  } catch (error) {
+    logger.error("[Navigation] Error processing URL:", error);
+    return Promise.reject(error);
   }
-  if (isGroupInviteLink(url)) {
-    return originalOpenURL(getSchemedURLFromUniversalURL(url));
-  }
-  if (isGroupLink(url)) {
-    return originalOpenURL(getSchemedURLFromUniversalURL(url));
-  }
-  return originalOpenURL(url);
 };


### PR DESCRIPTION
Deep linking was causing crashes due to attempts to access the `routes` property in an undefined navigation state. This occurred because the navigation state wasn't properly initialized before processing URLs, and also, handling for such `inviteId` was missing.

### Testing

Please verify/double check deep linking functionality for:
- Group invites
- DM links
- Regular group links
- Invalid/malformed links

Fixes [#1380](https://github.com/ephemeraHQ/converse-app/issues/1380)