### PR TITLE
fix: EAS Node Versions

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,10 +2,10 @@
   "expo": {
     "version": "2.1.0",
     "ios": {
-      "buildNumber": "51"
+      "buildNumber": "52"
     },
     "android": {
-      "versionCode": 250
+      "versionCode": 251
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -2,10 +2,10 @@
   "expo": {
     "version": "2.1.0",
     "ios": {
-      "buildNumber": "50"
+      "buildNumber": "51"
     },
     "android": {
-      "versionCode": 249
+      "versionCode": 250
     }
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -11,7 +11,7 @@
       "env": {
         "EXPO_ENV": "dev"
       },
-      "node": "20.15.1",
+      "node": "20.18.0",
       "ios": {
         "cocoapods": "1.16.2",
         "image": "macos-sonoma-14.6-xcode-16.1"
@@ -27,7 +27,7 @@
         "buildType": "app-bundle",
         "resourceClass": "large"
       },
-      "node": "20.15.1",
+      "node": "20.18.0",
       "ios": {
         "resourceClass": "large",
         "cocoapods": "1.16.2",

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -33,7 +33,6 @@ target 'Converse' do
   pod 'MMKV', $mmkvVersion, :linkage => :dynamic
   pod 'MMKVCore', $mmkvVersion, :linkage => :dynamic
   pod 'XMTP', $xmtpVersion, :modular_headers => true
-  pod "OpenSSL-Universal", "1.1.2200"
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -431,7 +431,7 @@ PODS:
   - MMKVAppExtension (1.3.3):
     - MMKVCore (~> 1.3.3)
   - MMKVCore (1.3.3)
-  - OpenSSL-Universal (1.1.2200)
+  - OpenSSL-Universal (3.3.2000)
   - PromisesObjC (2.4.0)
   - RCT-Folly (2024.01.01.00):
     - boost
@@ -2311,7 +2311,6 @@ DEPENDENCIES:
   - MMKV (= 1.3.3)
   - MMKVAppExtension (= 1.3.3)
   - MMKVCore (= 1.3.3)
-  - OpenSSL-Universal (= 1.1.2200)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -2795,7 +2794,7 @@ SPEC CHECKSUMS:
   MMKV: f902fb6719da13c2ab0965233d8963a59416f911
   MMKVAppExtension: fcf23c6b250cc87db63507bc57be8e6ed378168d
   MMKVCore: d26e4d3edd5cb8588c2569222cbd8be4231374e9
-  OpenSSL-Universal: 6e1ae0555546e604dbc632a2b9a24a9c46c41ef6
+  OpenSSL-Universal: b60a3702c9fea8b3145549d421fdb018e53ab7b4
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 34124ae2e667a0e5f0ea378db071d27548124321
   RCTDeprecation: 726d24248aeab6d7180dac71a936bbca6a994ed1
@@ -2899,8 +2898,8 @@ SPEC CHECKSUMS:
   UMAppLoader: f17a5ee8e85b536ace0fc254b447a37ed198d57e
   XMTP: b5311154b2a3cda7c07ce78ae9fa6d111bac979d
   XMTPReactNative: 2a8cb6762dd530574888fe1a0ea209baf33b3155
-  Yoga: a9ef4f5c2cd79ad812110525ef61048be6a582a4
+  Yoga: b05994d1933f507b0a28ceaa4fdb968dc18da178
 
-PODFILE CHECKSUM: d0979efccd68d98c9fc5de08ece9c978b5338ee0
+PODFILE CHECKSUM: cd340e2564f5ae6c64a51a8be3490a9179a697a7
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Node.js version from 20.15.1 to 20.18.0 in development and production environments.
- **New Features**
	- Incremented the iOS build number from 50 to 52.
	- Updated the Android version code from 249 to 251.
- **Bug Fixes**
	- Removed the OpenSSL-Universal pod dependency from the iOS project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->