### PR TITLE
fix: Clear Notifications when in app

### DIFF
--- a/features/notifications/utils/accountTopicSubscription.ts
+++ b/features/notifications/utils/accountTopicSubscription.ts
@@ -1,6 +1,7 @@
 import { createConversationListQueryObserver } from "@/queries/useConversationListQuery";
 import { subscribeToNotifications } from "./subscribeToNotifications";
 import logger from "@/utils/logger";
+import { resetNotifications } from "./resetNotifications";
 
 const accountTopicUnsubscribeMap: Record<string, () => void> = {};
 
@@ -26,6 +27,12 @@ export const setupAccountTopicSubscription = (account: string) => {
         conversations: conversationList.data,
         account,
       });
+      // For now just reset notifications when we get a new conversation list
+      /*
+        TODO: We can probably do better here
+        - Counter by account (Only clear the counter for the account we are subscribing to so users know they have new messages on other accounts)
+      */
+      resetNotifications();
     }
   });
   accountTopicUnsubscribeMap[account] = unsubscribe;


### PR DESCRIPTION
Clear notifications once they load

Closes https://github.com/ephemeraHQ/converse-app/issues/1442 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to reset notifications after receiving a new conversation list
- **Refactor**
	- Removed `handleOngoingConversationMessage` function from notification handling logic in iOS extension
- **Bug Fixes**
	- Improved notification management process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->