### PR TITLE
make logger light color scheme friendly

### DIFF
--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -69,16 +69,29 @@ const converseTransport: transportFunctionType = async (props) => {
   await RNFS.appendFile(loggingFilePath, `${props.msg}\n`, "utf8");
 };
 
+const developerSystemAppearance: "dark" | "light" = "light" as const;
+const darkSystemColorScheme = {
+  debug: "white",
+  info: "blueBright",
+  warn: "yellowBright",
+  error: "redBright",
+};
+
+const lightSystemColorScheme = {
+  debug: "black",
+  info: "blue",
+  warn: "orange",
+  error: "red",
+};
+
 const _logger = RNLogger.createLogger({
   severity: "debug", // @todo => change minimum severity according to env & user (debug addresses)
   transport: converseTransport,
   transportOptions: {
-    colors: {
-      debug: "white",
-      info: "blueBright",
-      warn: "yellowBright",
-      error: "redBright",
-    },
+    colors:
+      developerSystemAppearance === "dark"
+        ? darkSystemColorScheme
+        : lightSystemColorScheme,
   },
   levels: {
     debug: 0,

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -69,7 +69,7 @@ const converseTransport: transportFunctionType = async (props) => {
   await RNFS.appendFile(loggingFilePath, `${props.msg}\n`, "utf8");
 };
 
-const developerSystemAppearance: "dark" | "light" = "light" as const;
+const developerSystemAppearance: "dark" | "light" = "dark" as const;
 const darkSystemColorScheme = {
   debug: "white",
   info: "blueBright",
@@ -89,6 +89,7 @@ const _logger = RNLogger.createLogger({
   transport: converseTransport,
   transportOptions: {
     colors:
+      // @ts-ignore
       developerSystemAppearance === "dark"
         ? darkSystemColorScheme
         : lightSystemColorScheme,


### PR DESCRIPTION
### dark
![CleanShot 2025-01-02 at 16 22 47@2x](https://github.com/user-attachments/assets/9cc7cc60-9909-4a20-90c2-5bc15c62bf95)

### light
![CleanShot 2025-01-02 at 16 20 06@2x](https://github.com/user-attachments/assets/a457d954-f436-48e9-b3ae-08cb1f020063)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging functionality with dynamic color schemes based on system appearance (dark or light mode)
	- Improved visual representation of log messages that adapt to user's system settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->