### PR TITLE
fix: Add back button

### DIFF
--- a/features/conversation/conversation.nav.tsx
+++ b/features/conversation/conversation.nav.tsx
@@ -24,7 +24,7 @@ export function ConversationNav() {
       options={{
         title: "",
         headerBackTitle: "",
-        headerBackVisible: false,
+        // headerBackVisible: false,
       }}
       name="Conversation"
       component={ConversationScreen}


### PR DESCRIPTION
Added back button back for conversation screen

This was likely an issue with expo 52 upgrade and header changes happening at the same time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted navigation header back button visibility to use default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->