### PR TITLE
fix: Avatar styles

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -47,7 +47,7 @@ function Avatar({
     setDidError(false);
   }, []);
   return uri && !didError ? (
-    <View style={[styles.imageContainer, style]}>
+    <View style={style}>
       <Image
         onLoad={handleImageLoad}
         onError={handleImageError}
@@ -88,8 +88,6 @@ const getStyles = (
   StyleSheet.create({
     image: {
       borderRadius: size,
-    },
-    imageContainer: {
       width: size,
       height: size,
     },

--- a/screens/NewAccount/NewAccountConnectWalletScreen.tsx
+++ b/screens/NewAccount/NewAccountConnectWalletScreen.tsx
@@ -20,7 +20,7 @@ export const NewAccountConnectWalletScreen = memo(
         if (isMissingConverseProfile()) {
           router.navigate("NewAccountUserProfile");
         } else {
-          router.navigate("Chats");
+          router.popTo("Chats");
         }
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/screens/NewAccount/NewAccountEphemeraScreen.tsx
+++ b/screens/NewAccount/NewAccountEphemeraScreen.tsx
@@ -37,7 +37,7 @@ export function NewAccountEphemeraScreen(
       if (isMissingConverseProfile()) {
         router.navigate("NewAccountUserProfile");
       } else {
-        router.navigate("Chats");
+        router.popTo("Chats");
       }
     } catch (error) {
       sentryTrackError(error);

--- a/screens/NewAccount/NewAccountPrivateKeyScreen.tsx
+++ b/screens/NewAccount/NewAccountPrivateKeyScreen.tsx
@@ -31,7 +31,7 @@ export const NewAccountPrivateKeyScreen = memo(function () {
       if (isMissingConverseProfile()) {
         router.navigate("NewAccountUserProfile");
       } else {
-        router.navigate("Chats");
+        router.popTo("Chats");
       }
     } catch (error) {
       sentryTrackError(error);

--- a/screens/NewAccount/NewAccountPrivyScreen.tsx
+++ b/screens/NewAccount/NewAccountPrivyScreen.tsx
@@ -33,7 +33,7 @@ const Content = memo(function Content() {
       if (isMissingConverseProfile()) {
         router.navigate("NewAccountUserProfile");
       } else {
-        router.navigate("Chats");
+        router.popTo("Chats");
       }
     },
     onConnectionError: (error) => {

--- a/screens/NewAccount/NewAccountUserProfileScreen.tsx
+++ b/screens/NewAccount/NewAccountUserProfileScreen.tsx
@@ -42,12 +42,12 @@ export const NewAccountUserProfileScreen = memo(
       try {
         const { success } = await createOrUpdateProfile({ profile });
         if (success) {
-          navigation.navigate("Chats");
+          navigation.popTo("Chats");
         }
       } catch (error) {
         sentryTrackError(error);
       }
-    }, [createOrUpdateProfile, profile, navigation]);
+    }, [createOrUpdateProfile, navigation, profile]);
 
     const usernameRef = useRef<TextInput>();
 


### PR DESCRIPTION
With Expo 52 upgrade I removed an unnecessary Image Background (updated designs didn't need it) for Image but didn't update the styles correctly to set a height/width
![Simulator Screenshot - iPhone 15 - 2025-01-08 at 19 33 24](https://github.com/user-attachments/assets/81e9936d-e124-4512-b5f0-1b9e01350004)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated navigation behavior to return to the "Chats" screen instead of creating a new instance across multiple components in the New Account flow.
- **Style**
	- Updated Avatar component styling to simplify image container rendering.
	- Removed dedicated image container style properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->