### PR TITLE
fix: add 1px border to message attachments

### DIFF
--- a/features/conversation/conversation-attachment/conversation-attachment-container.tsx
+++ b/features/conversation/conversation-attachment/conversation-attachment-container.tsx
@@ -20,6 +20,8 @@ export const AttachmentContainer = memo(function AttachmentContainer(
           alignItems: "center",
           backgroundColor: theme.colors.fill.tertiary,
           aspectRatio: 1.5, // Default aspect ratio for attachments
+          borderWidth: theme.borderWidth.sm, // 1px border width
+          borderColor: theme.colors.border.edge, // Using edge color for subtle border
         },
         style,
       ]}


### PR DESCRIPTION
## Description

This PR adds a 1px border to message attachments to improve visual definition and match the design requirements. The border uses the theme's edge color for consistent styling across light and dark themes.

## Changes

- Added `borderWidth: theme.borderWidth.sm` (1px) to the `AttachmentContainer` component
- Added `borderColor: theme.colors.border.edge` for a subtle border that works in both light and dark themes

## Testing

- [ ] Verify border appears correctly on message attachments
- [ ] Verify border color is appropriate in both light and dark themes
- [ ] Verify border doesn't interfere with existing attachment interactions

Fixes #1613