### PR TITLE
Fix: Remove opacity effect on button press

### DIFF
--- a/design-system/Button/Button.styles.ts
+++ b/design-system/Button/Button.styles.ts
@@ -86,13 +86,8 @@ export const getButtonViewStyle =
         case "link":
         case "text":
           style.backgroundColor = "transparent";
-          // Put back when we're done refactoring all the variant="text" button
-          // if (pressed) {
-          //   style.backgroundColor = colors.fill.minimal;
-          // }
-          // Temporary opacity change for the variant="text" button
           if (pressed) {
-            style.opacity = 0.8;
+            style.backgroundColor = colors.fill.minimal;
           }
           break;
 


### PR DESCRIPTION
## Description
This PR removes the opacity effect when pressing buttons with the "text" or "link" variants and replaces it with a background color change instead.

## Changes
- Removed the `style.opacity = 0.8` line that was applied when a button was pressed
- Uncommented and enabled the `style.backgroundColor = colors.fill.minimal` line to provide visual feedback when a button is pressed

## Why
The opacity effect was making the button content less visible when pressed, which could affect usability. Using a background color change provides better visual feedback without reducing content visibility.

## Testing
Tested with various button variants to ensure the press state is still visually distinct but without the opacity reduction.